### PR TITLE
Updates to Spectral & TimeFrequency

### DIFF
--- a/neurodsp/filt.py
+++ b/neurodsp/filt.py
@@ -571,7 +571,7 @@ def _remove_nans(sig):
     return sig_removed, sig_nans
 
 
-def _restore_nans(sig, sig_nans):
+def _restore_nans(sig, sig_nans, dtype=float):
     """Restore NaN values to the edges of a 1d array.
 
     Parameters
@@ -587,7 +587,7 @@ def _restore_nans(sig, sig_nans):
         Signal with NaN edges restored.
     """
 
-    sig_restored = np.ones(len(sig_nans)) * np.nan
+    sig_restored = np.ones(len(sig_nans), dtype=dtype) * np.nan
     sig_restored[~sig_nans] = sig
 
     return sig_restored

--- a/neurodsp/filt.py
+++ b/neurodsp/filt.py
@@ -546,6 +546,37 @@ def compute_nyquist(fs):
 
     return fs / 2.
 
+
+def infer_passtype(fc):
+    """Given frequency definition of a filter, infer the passtype.
+
+    Parameters
+    ----------
+    fc : tuple of (float, float)
+        Cutoff frequency(ies) used for filter, specified as f_lo & f_hi.
+
+    Returns
+    -------
+    pass_type : str
+        Which kind of filter pass_type is consistent with the frequency definition provided.
+
+    Notes
+    -----
+    Assumes that a definition with two frequencies is a 'bandpass' (not 'bandstop').
+    """
+
+    if fc[0] is None:
+        pass_type = 'lowpass'
+    elif fc[1] is None:
+        pass_type = 'highpass'
+    else:
+        pass_type = 'bandpass'
+
+    # Check the inferred passtype & frequency definition is valid
+    _ = check_filter_definition(pass_type, fc)
+
+    return pass_type
+
 ###################################################################################################
 ###################################################################################################
 

--- a/neurodsp/timefrequency.py
+++ b/neurodsp/timefrequency.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy import signal
 
 import neurodsp
-from neurodsp.filt import filter_signal
+from neurodsp.filt import filter_signal, infer_passtype
 from neurodsp.filt import _drop_edge_artifacts, _remove_nans, _restore_nans
 
 ###################################################################################################
@@ -45,7 +45,7 @@ def phase_by_time(sig, fs, f_range, filter_kwargs={}, hilbert_increase_n=False,
     if filter_kwargs is None:
         filter_kwargs = {}
 
-    pass_type = _get_filt_passtype(f_range)
+    pass_type = infer_passtype(f_range)
 
     # Filter signal
     sig_filt, kernel = filter_signal(sig, fs, pass_type, fc=f_range,
@@ -96,7 +96,7 @@ def amp_by_time(sig, fs, f_range, filter_kwargs=None, hilbert_increase_n=False,
     if filter_kwargs is None:
         filter_kwargs = {}
 
-    pass_type = _get_filt_passtype(f_range)
+    pass_type = infer_passtype(f_range)
 
     # Filter signal
     sig_filt, kernel = filter_signal(sig, fs, pass_type, fc=f_range,
@@ -180,21 +180,3 @@ def _hilbert_ignore_nan(sig, hilbert_increase_n=False):
     sig_hilb = _restore_nans(sig_hilb_nonan, sig_nans, dtype=complex)
 
     return sig_hilb
-
-
-def _get_filt_passtype(f_range):
-    """Given frequency range of filter, check for Nones to return
-    appropriate filter pass_type to filt.filter_signal.
-    """
-
-    if f_range[0] is None:
-        pass_type = 'lowpass'
-    elif f_range[1] is None:
-        pass_type = 'highpass'
-    else:
-        if f_range[0] >= f_range[1]:
-            raise ValueError('Second cutoff frequency must be greater than first.')
-        else:
-            pass_type = 'bandpass'
-
-    return pass_type


### PR DESCRIPTION
Non API breaking refactors and clean ups of the spectral & time frequency module. (Somewhat related to #140 - but nothing that breaks anything here). 

Main changes:
- Split up sub-function for settings checking, discarding outliers and sub-selecting from spectra
- Split out the different compute spectrum methods
- Get time frequency to borrow & use the utility functions that were split out in `filter` (get rid of duplicated code within `timefrequency`, and across the package. This includes moving & renaming a 'infer_passtype' from tf -> filt. 

Notably, this fixes a bug in which the old version would fail out if you tried to discard outliers in compute_spectrum with a 1d signal. 