### PR TITLE
[DOC] examples added to docstrings

### DIFF
--- a/neurodsp/burst/dualthresh.py
+++ b/neurodsp/burst/dualthresh.py
@@ -49,15 +49,13 @@ def detect_bursts_dual_threshold(sig, fs, dual_thresh, f_range=None,
 
     Examples
     --------
-
-    Detect burst in a simulated signal using the dual threshold algorithm:
+    Detect bursts in using the dual threshold algorithm:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(8, 12))
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(8, 12))
 
     """
 

--- a/neurodsp/burst/dualthresh.py
+++ b/neurodsp/burst/dualthresh.py
@@ -49,14 +49,14 @@ def detect_bursts_dual_threshold(sig, fs, dual_thresh, f_range=None,
 
     Examples
     --------
-    Detect bursts in using the dual threshold algorithm:
+    Detect bursts using the dual threshold algorithm:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=[0.1, 0.9])
     >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(8, 12))
-
     """
 
     if len(dual_thresh) != 2:

--- a/neurodsp/burst/dualthresh.py
+++ b/neurodsp/burst/dualthresh.py
@@ -46,6 +46,19 @@ def detect_bursts_dual_threshold(sig, fs, dual_thresh, f_range=None,
     is_burst : 1d array
         Boolean indication of where bursts are present in the input signal.
         True indicates that a burst was detected at that sample, otherwise False.
+
+    Examples
+    --------
+
+    Detect burst in a simulated signal using the dual threshold algorithm:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(8, 12))
+
     """
 
     if len(dual_thresh) != 2:
@@ -73,7 +86,7 @@ def detect_bursts_dual_threshold(sig, fs, dual_thresh, f_range=None,
     # Otherwise, make sure minimum duration is set, and use that
     else:
         if min_burst_duration is None:
-            raise ValueError("Minimum burst duration must be defined if not filtering"
+            raise ValueError("Minimum burst duration must be defined if not filtering "
                              "and using a number of cycles threshold.")
         min_burst_samples = int(np.ceil(min_burst_duration * fs))
 

--- a/neurodsp/burst/utils.py
+++ b/neurodsp/burst/utils.py
@@ -38,7 +38,6 @@ def compute_burst_stats(bursting, fs):
     ...                                'sim_bursty_oscillation' : {'freq': 10}})
     >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(8, 12))
     >>> stats_dict = compute_burst_stats(is_burst, fs=500)
-
     """
 
     tot_time = len(bursting) / fs

--- a/neurodsp/burst/utils.py
+++ b/neurodsp/burst/utils.py
@@ -25,6 +25,20 @@ def compute_burst_stats(bursting, fs):
         * `duration_std`: standard deviation of burst durations, in seconds
         * `percent_burst`: percent time in bursts
         * `burst_rate`: bursts/sec
+
+    Examples
+    --------
+    Compute statistics of detected bursts in a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.burst import detect_bursts_dual_threshold
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(8, 12))
+    >>> stats_dict = compute_burst_stats(is_burst, fs)
+
     """
 
     tot_time = len(bursting) / fs

--- a/neurodsp/burst/utils.py
+++ b/neurodsp/burst/utils.py
@@ -28,16 +28,16 @@ def compute_burst_stats(bursting, fs):
 
     Examples
     --------
-    Compute statistics of detected bursts in a simulated signal:
+    Compute statistics of detected bursts:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.burst import detect_bursts_dual_threshold
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(8, 12))
-    >>> stats_dict = compute_burst_stats(is_burst, fs)
+
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(8, 12))
+    >>> stats_dict = compute_burst_stats(is_burst, fs=500)
 
     """
 

--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -39,14 +39,14 @@ def check_filter_definition(pass_type, f_range):
 
     Examples
     --------
-    An error is raised for invalid filters:
+    An error is raised for invalid filters. Note that this example would fail since a bandpass
+    filter requires two values for ``f_range``.
 
     >>> try:
     ...     f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(20))
     ... except ValueError:
     ...     print("The filter definition is invalid.")
     The filter definition is invalid.
-    # Note that this example would fail since a bandpass filter requires two values for ``f_range``.
 
     Whereas cutoff frequencies are computed for valid filers:
 

--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -36,6 +36,21 @@ def check_filter_definition(pass_type, f_range):
     ------
     ValueError
         If the filter passtype it not understood, or cutoff frequencies are incompatible.
+
+    Examples
+    --------
+    An error is raised for invalid filters:
+
+    >>> try:
+    ...     f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(20))
+    ... except ValueError:
+    ...     print("f_range for a bandpass filter requires a two cutoff freqeuncies.")
+    f_range for a bandpass filter requires a two cutoff freqeuncies.
+
+    Whereas cutoff frequencies are returned for valid filers:
+
+    >>> f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(5, 25))
+
     """
 
     if pass_type not in ['bandpass', 'bandstop', 'lowpass', 'highpass']:
@@ -106,6 +121,18 @@ def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range, transitions=
     -------
     passes : bool
         Whether all the checks pass. False if one or more checks fail.
+
+    Examples
+    --------
+    Design an IIF filter and check its properties:
+
+    >>> from neurodsp.filt import design_iir_filter
+    >>> fs = 500
+    >>> b_vals, a_vals = design_iir_filter(fs, pass_type='bandstop',
+    ...                                    f_range=(10, 20), butterworth_order=7)
+    >>> passes = check_filter_properties(b_vals, a_vals, fs, pass_type='bandstop', f_range=(10, 20))
+    Transition bandwidth is 2.0 Hz.
+    Pass/stop bandwidth is 10.0 Hz.
     """
 
     # Import utility functions inside function to avoid circular imports

--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -44,10 +44,11 @@ def check_filter_definition(pass_type, f_range):
     >>> try:
     ...     f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(20))
     ... except ValueError:
-    ...     print("f_range for a bandpass filter requires a two cutoff freqeuncies.")
-    f_range for a bandpass filter requires a two cutoff freqeuncies.
+    ...     print("The filter definition is invalid.")
+    The filter definition is invalid.
+    # Note that this example would fail since a bandpass filter requires two values for ``f_range``.
 
-    Whereas cutoff frequencies are returned for valid filers:
+    Whereas cutoff frequencies are computed for valid filers:
 
     >>> f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(5, 25))
 
@@ -124,13 +125,13 @@ def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range, transitions=
 
     Examples
     --------
-    Design an IIF filter and check its properties:
+    Check the properties of an IIR filter:
 
     >>> from neurodsp.filt import design_iir_filter
-    >>> fs = 500
-    >>> b_vals, a_vals = design_iir_filter(fs, pass_type='bandstop',
+    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
     ...                                    f_range=(10, 20), butterworth_order=7)
-    >>> passes = check_filter_properties(b_vals, a_vals, fs, pass_type='bandstop', f_range=(10, 20))
+    >>> passes = check_filter_properties(b_vals, a_vals, fs=500,
+    ...                                  pass_type='bandstop', f_range=(10, 20))
     Transition bandwidth is 2.0 Hz.
     Pass/stop bandwidth is 10.0 Hz.
     """

--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -39,19 +39,18 @@ def check_filter_definition(pass_type, f_range):
 
     Examples
     --------
-    An error is raised for invalid filters. Note that this example would fail since a bandpass
-    filter requires two values for ``f_range``.
+    Check a filter definition, and get the cutoff frequencies returned, if the filter is valid:
+
+    >>> f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(5, 25))
+
+    Check a filter defition, for an invalid filter.
+    This example fails since a bandpass filter requires two values for ``f_range``.
 
     >>> try:
     ...     f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(20))
     ... except ValueError:
     ...     print("The filter definition is invalid.")
     The filter definition is invalid.
-
-    Whereas cutoff frequencies are computed for valid filers:
-
-    >>> f_hi, f_lo = check_filter_definition(pass_type='bandpass', f_range=(5, 25))
-
     """
 
     if pass_type not in ['bandpass', 'bandstop', 'lowpass', 'highpass']:
@@ -90,7 +89,8 @@ def check_filter_definition(pass_type, f_range):
     return f_lo, f_hi
 
 
-def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range, transitions=(-20, -3), verbose=True):
+def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range,
+                            transitions=(-20, -3), verbose=True):
     """Check a filters properties, including pass band and transition band.
 
     Parameters
@@ -125,14 +125,22 @@ def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range, transitions=
 
     Examples
     --------
+    Check the properties of an FIR filter:
+
+    >>> from neurodsp.filt.fir import design_fir_filter
+    >>> fs, pass_type, f_range = 500, 'bandpass', (1, 25)
+    >>> filter_coefs = design_fir_filter(fs, pass_type, f_range)
+    >>> passes = check_filter_properties(filter_coefs, 1, fs, pass_type, f_range)
+    Transition bandwidth is 0.5 Hz.
+    Pass/stop bandwidth is 24.0 Hz.
+
     Check the properties of an IIR filter:
 
-    >>> from neurodsp.filt import design_iir_filter
-    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
-    ...                                    f_range=(10, 20), butterworth_order=7)
-    >>> passes = check_filter_properties(b_vals, a_vals, fs=500,
-    ...                                  pass_type='bandstop', f_range=(10, 20))
-    Transition bandwidth is 2.0 Hz.
+    >>> from neurodsp.filt.iir import design_iir_filter
+    >>> fs, pass_type, f_range, order = 500, 'bandstop', (55, 65), 7
+    >>> b_vals, a_vals = design_iir_filter(fs, pass_type, f_range, order)
+    >>> passes = check_filter_properties(b_vals, a_vals, fs, pass_type, f_range)
+    Transition bandwidth is 1.5 Hz.
     Pass/stop bandwidth is 10.0 Hz.
     """
 

--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -62,14 +62,13 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
 
     Examples
     --------
-    Simulate a signal and apply a band pass filter:
+    Apply a band pass filter:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filt_sig = filter_signal(sig, fs, pass_type='bandpass', f_range=(1, 25))
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal(sig, fs=500, pass_type='bandpass', f_range=(1, 25))
 
     """
 

--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -59,6 +59,18 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
         Filtered time series.
     kernel : 1d array or tuple of (1d array, 1d array)
         Filter coefficients. Only returned if `return_filter` is True.
+
+    Examples
+    --------
+    Simulate a signal and apply a band pass filter:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal(sig, fs, pass_type='bandpass', f_range=(1, 25))
+
     """
 
     if filter_type == 'fir':

--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -62,21 +62,20 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
 
     Examples
     --------
-    Apply a band pass filter:
+    Apply an FIR band pass filter to a signal, for the range of 1 to 25 Hz:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filt_sig = filter_signal(sig, fs=500, pass_type='bandpass', f_range=(1, 25))
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal(sig, fs=500, pass_type='bandpass',
+    ...                          filter_type='fir', f_range=(1, 25))
     """
 
-    if filter_type == 'fir':
+    if filter_type.lower() == 'fir':
         return filter_signal_fir(sig, fs, pass_type, f_range, n_cycles, n_seconds,
                                  remove_edges, print_transitions,
                                  plot_properties, return_filter)
-    elif filter_type == 'iir':
+    elif filter_type.lower() == 'iir':
         _iir_checks(n_seconds, butterworth_order, remove_edges)
         return filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
                                  print_transitions, plot_properties,

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -212,7 +212,7 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
     --------
     Compute the length of bandpass (1 to 25 hz) filter:
 
-    >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25)
+    >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25, n_cycles=3)
 
     """
 

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -54,6 +54,18 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
         Filtered time series.
     filter_coefs : 1d array
         Filter coefficients of the FIR filter. Only returned if `return_filter` is True.
+
+    Examples
+    --------
+    Simulate a signal and apply a band pass filter:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal_fir(sig, fs, pass_type='bandpass', f_range=(1, 25))
+
     """
 
     # Design filter & check that the length is okay with signal
@@ -102,6 +114,19 @@ def apply_fir_filter(sig, filter_coefs):
     -------
     array
         Filtered time series.
+
+    Examples
+    --------
+    Simulate a signal, design a filter, and apply that filter to the simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 25))
+    >>> filt_sig = apply_fir_filter(sig, filter_coefs)
+
     """
 
     return np.convolve(filter_coefs, sig, 'same')
@@ -136,6 +161,13 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
     -------
     filter_coefs : 1d array
         The filter coefficients for an FIR filter.
+
+    Examples
+    --------
+    Return a bandpass FIR filter:
+
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
+
     """
 
     # Check filter definition
@@ -155,7 +187,7 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
     return filter_coefs
 
 
-def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=None):
+def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=3, n_seconds=None):
     """Compute the filter length for an FIR signal given specified parameters.
 
     Parameters
@@ -177,6 +209,13 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
     -------
     filt_len : int
         The length of the specified filter.
+
+    Examples
+    --------
+    Return the length of bandpass (1 to 25 hz) filter:
+
+    >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25)
+
     """
 
     # Compute filter length if specified in seconds

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -60,11 +60,10 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
     Simulate a signal and apply a band pass filter:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filt_sig = filter_signal_fir(sig, fs, pass_type='bandpass', f_range=(1, 25))
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal_fir(sig, fs=500, pass_type='bandpass', f_range=(1, 25))
 
     """
 
@@ -117,14 +116,13 @@ def apply_fir_filter(sig, filter_coefs):
 
     Examples
     --------
-    Simulate a signal, design a filter, and apply that filter to the simulated signal:
+    Apply an FIR filter:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 25))
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     >>> filt_sig = apply_fir_filter(sig, filter_coefs)
 
     """
@@ -164,7 +162,7 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
 
     Examples
     --------
-    Return a bandpass FIR filter:
+    Create the filter coefficients for a FIR filter:
 
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
 
@@ -187,7 +185,7 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
     return filter_coefs
 
 
-def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=3, n_seconds=None):
+def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=None):
     """Compute the filter length for an FIR signal given specified parameters.
 
     Parameters
@@ -200,7 +198,7 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=3, n_seconds=None)
         The lower frequency range of the filter, specifying the highpass frequency, if specified.
     f_hi : float or None
         The higher frequency range of the filter, specifying the lowpass frequency, if specified.
-    n_cycles : float or None, optional, default: 3
+    n_cycles : float or None, optional
         Length of filter, in number of cycles, defined at the 'f_lo' frequency.
     n_seconds : float or None, optional
         Length of filter, in seconds.
@@ -212,7 +210,7 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=3, n_seconds=None)
 
     Examples
     --------
-    Return the length of bandpass (1 to 25 hz) filter:
+    Compute the length of bandpass (1 to 25 hz) filter:
 
     >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25)
 

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -7,7 +7,8 @@ from neurodsp.utils import remove_nans, restore_nans
 from neurodsp.utils.decorators import multidim
 from neurodsp.plts.filt import plot_filter_properties
 from neurodsp.filt.utils import compute_nyquist, compute_frequency_response, remove_filter_edges
-from neurodsp.filt.checks import check_filter_definition, check_filter_properties, check_filter_length
+from neurodsp.filt.checks import (check_filter_definition, check_filter_properties,
+                                  check_filter_length)
 
 ###################################################################################################
 ###################################################################################################
@@ -57,14 +58,18 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
 
     Examples
     --------
-    Simulate a signal and apply a band pass filter:
+    Apply a band pass FIR filter to a simulated signal:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> filt_sig = filter_signal_fir(sig, fs=500, pass_type='bandpass', f_range=(1, 25))
 
+    Apply a high pass FIR filter to a signal, with a specified number of cycles:
+
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal_fir(sig, fs=500, pass_type='highpass', f_range=(2, None), n_cycles=5)
     """
 
     # Design filter & check that the length is okay with signal
@@ -116,15 +121,13 @@ def apply_fir_filter(sig, filter_coefs):
 
     Examples
     --------
-    Apply an FIR filter:
+    Apply an FIR filter, from computed filter coefficients:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     >>> filt_sig = apply_fir_filter(sig, filter_coefs)
-
     """
 
     return np.convolve(filter_coefs, sig, 'same')
@@ -162,10 +165,9 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
 
     Examples
     --------
-    Create the filter coefficients for a FIR filter:
+    Create the filter coefficients for an FIR filter:
 
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
-
     """
 
     # Check filter definition
@@ -213,7 +215,6 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
     Compute the length of bandpass (1 to 25 hz) filter:
 
     >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25, n_cycles=3)
-
     """
 
     # Compute filter length if specified in seconds

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -54,14 +54,12 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
 
     Examples
     --------
-    Simulate a signal and apply a bandstop IIR filter:
+    Apply a bandstop IIR filter:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    >>> sig = sim_combined(n_seconds=10, fs=500, components={'sim_synaptic_current': {},
     ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filt_sig = filter_signal_iir(sig, fs, pass_type='bandstop', f_range=(10, 20),
+    >>> filt_sig = filter_signal_iir(sig, fs=500, pass_type='bandstop', f_range=(10, 20),
     ...                              butterworth_order=7)
 
     """
@@ -111,14 +109,13 @@ def apply_iir_filter(sig, b_vals, a_vals):
 
     Examples
     --------
-    Simulate a signal, design an IIR filter, and apply the filter:
+    Apply an IIR filter:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> b_vals, a_vals = design_iir_filter(fs, pass_type='bandstop',
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
     ...                                    f_range=(10, 20), butterworth_order=7)
     >>> filt_signal = apply_iir_filter(sig, b_vals, a_vals)
 
@@ -159,7 +156,7 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
 
     Examples
     --------
-    Design and return coeffecicients for a bandstop IIR filter:
+    Compute coefficients for a bandstop IIR filter:
 
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
     ...                                    f_range=(10, 20), butterworth_order=7)

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -54,14 +54,13 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
 
     Examples
     --------
-    Apply a bandstop IIR filter:
+    Apply a bandstop IIR filter to a simulated signal:
 
     >>> from neurodsp.sim import sim_combined
-    >>> sig = sim_combined(n_seconds=10, fs=500, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filt_sig = filter_signal_iir(sig, fs=500, pass_type='bandstop', f_range=(10, 20),
-    ...                              butterworth_order=7)
-
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal_iir(sig, fs=500, pass_type='bandstop',
+    ...                              f_range=(55, 65), butterworth_order=7)
     """
 
     # Design filter
@@ -109,16 +108,14 @@ def apply_iir_filter(sig, b_vals, a_vals):
 
     Examples
     --------
-    Apply an IIR filter:
+    Apply an IIR filter, after designing the filter coefficients:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
-    ...                                    f_range=(10, 20), butterworth_order=7)
+    ...                                    f_range=(55, 65), butterworth_order=7)
     >>> filt_signal = apply_iir_filter(sig, b_vals, a_vals)
-
     """
 
     return filtfilt(b_vals, a_vals, sig)
@@ -159,8 +156,7 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
     Compute coefficients for a bandstop IIR filter:
 
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
-    ...                                    f_range=(10, 20), butterworth_order=7)
-
+    ...                                    f_range=(55, 65), butterworth_order=7)
     """
 
     # Warn about only recommending IIR for bandstop

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -51,6 +51,19 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     filter_coefs : tuple of (1d array, 1d array)
         Filter coefficients of the IIR filter, as (b_vals, a_vals).
         Only returned if `return_filter` is True.
+
+    Examples
+    --------
+    Simulate a signal and apply a bandstop IIR filter:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filt_sig = filter_signal_iir(sig, fs, pass_type='bandstop', f_range=(10, 20),
+    ...                              butterworth_order=7)
+
     """
 
     # Design filter
@@ -95,6 +108,20 @@ def apply_iir_filter(sig, b_vals, a_vals):
     -------
     array
         Filtered time series.
+
+    Examples
+    --------
+    Simulate a signal, design an IIR filter, and apply the filter:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> b_vals, a_vals = design_iir_filter(fs, pass_type='bandstop',
+    ...                                    f_range=(10, 20), butterworth_order=7)
+    >>> filt_signal = apply_iir_filter(sig, b_vals, a_vals)
+
     """
 
     return filtfilt(b_vals, a_vals, sig)
@@ -129,6 +156,14 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
         B value filter coefficients for an IIR filter.
     a_vals : 1d array
         A value filter coefficients for an IIR filter.
+
+    Examples
+    --------
+    Design and return coeffecicients for a bandstop IIR filter:
+
+    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
+    ...                                    f_range=(10, 20), butterworth_order=7)
+
     """
 
     # Warn about only recommending IIR for bandstop

--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -61,7 +61,7 @@ def compute_frequency_response(b_vals, a_vals, fs):
 
     Examples
     --------
-    Simulate an IIR filter and compute the frequency response:
+    Compute the frequency response for an IIR filter:
 
     >>> from neurodsp.filt import design_iir_filter
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
@@ -143,7 +143,7 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
 
     Examples
     --------
-    Design a filter, compute f_db and db, and then compute the tranistion band:
+    Compute the transition band of an IIR filter, using the computed frequency response:
 
     >>> from neurodsp.filt import design_iir_filter
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
@@ -177,7 +177,7 @@ def compute_nyquist(fs):
 
     Examples
     --------
-    Compute the Nyquist frequency of 500 Hz sampling rate:
+    Compute the Nyquist frequency for a 500 Hz sampling rate:
 
     >>> compute_nyquist(fs=500)
     250.0
@@ -205,15 +205,14 @@ def remove_filter_edges(sig, filt_len):
 
     Examples
     --------
-    Simulate and filter a signal, and remove the filter edges:
+    Remove the filter edges of a filtered signal:
 
     >>> from neurodsp.filt.fir import design_fir_filter, apply_fir_filter
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 25))
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     >>> filt_sig = apply_fir_filter(sig, filter_coefs)
     >>> filt_sig_no_edges = remove_filter_edges(filt_sig, filt_len=len(filter_coefs))
 

--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -58,6 +58,16 @@ def compute_frequency_response(b_vals, a_vals, fs):
         Frequency vector corresponding to attenuation decibels, in Hz.
     db : 1d array
         Degree of attenuation for each frequency specified in `f_db`, in dB.
+
+    Examples
+    --------
+    Simulate an IIR filter and compute the frequency response:
+
+    >>> from neurodsp.filt import design_iir_filter
+    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
+    ...                                    f_range=(10, 20), butterworth_order=7)
+    >>> f_db, db = compute_frequency_response(b_vals, a_vals, fs=500)
+
     """
 
     w_vals, h_vals = freqz(b_vals, a_vals, worN=int(fs * 2))
@@ -91,6 +101,14 @@ def compute_pass_band(fs, pass_type, f_range):
     -------
     pass_bw : float
         The pass bandwidth of the filter.
+
+    Examples
+    --------
+    Compute the bandwith of a bandpass filter:
+
+    >>> compute_pass_band(fs=500, pass_type='bandpass', f_range=(5, 25))
+    20.0
+
     """
 
     f_lo, f_hi = check_filter_definition(pass_type, f_range)
@@ -122,6 +140,18 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
     -------
     transition_band : float
         The transition bandwidth of the filter.
+
+    Examples
+    --------
+    Design a filter, compute f_db and db, and then compute the tranistion band:
+
+    >>> from neurodsp.filt import design_iir_filter
+    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
+    ...                                    f_range=(10, 20), butterworth_order=7)
+    >>> f_db, db = compute_frequency_response(b_vals, a_vals, fs=500)
+    >>> compute_transition_band(f_db, db, low=-20, high=-3)
+    2.0
+
     """
 
     # This gets the indices of transitions to the values in searched for range
@@ -144,6 +174,14 @@ def compute_nyquist(fs):
     -------
     float
         The Nyquist frequency of a signal with the given sampling rate, in Hz.
+
+    Examples
+    --------
+    Compute the Nyquist frequency of 500 Hz sampling rate:
+
+    >>> compute_nyquist(fs=500)
+    250.0
+
     """
 
     return fs / 2.
@@ -164,6 +202,21 @@ def remove_filter_edges(sig, filt_len):
     -------
     sig : 1d array
         Filter signal with edge artifacts switched to NaNs.
+
+    Examples
+    --------
+    Simulate and filter a signal, and remove the filter edges:
+
+    >>> from neurodsp.filt.fir import design_fir_filter, apply_fir_filter
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 25))
+    >>> filt_sig = apply_fir_filter(sig, filter_coefs)
+    >>> filt_sig_no_edges = remove_filter_edges(filt_sig, filt_len=len(filter_coefs))
+
     """
 
     n_rmv = int(np.ceil(filt_len / 2))

--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -61,13 +61,18 @@ def compute_frequency_response(b_vals, a_vals, fs):
 
     Examples
     --------
+    Compute the frequency response for an FIR filter:
+
+    >>> from neurodsp.filt.fir import design_fir_filter
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(8, 12))
+    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs=500)
+
     Compute the frequency response for an IIR filter:
 
-    >>> from neurodsp.filt import design_iir_filter
+    >>> from neurodsp.filt.iir import design_iir_filter
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
-    ...                                    f_range=(10, 20), butterworth_order=7)
+    ...                                    f_range=(55, 65), butterworth_order=7)
     >>> f_db, db = compute_frequency_response(b_vals, a_vals, fs=500)
-
     """
 
     w_vals, h_vals = freqz(b_vals, a_vals, worN=int(fs * 2))
@@ -108,7 +113,6 @@ def compute_pass_band(fs, pass_type, f_range):
 
     >>> compute_pass_band(fs=500, pass_type='bandpass', f_range=(5, 25))
     20.0
-
     """
 
     f_lo, f_hi = check_filter_definition(pass_type, f_range)
@@ -143,15 +147,22 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
 
     Examples
     --------
+    Compute the transition band of an FIR filter, using the computed frequency response:
+
+    >>> from neurodsp.filt.fir import design_fir_filter
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
+    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs=500)
+    >>> compute_transition_band(f_db, db, low=-20, high=-3)
+    0.5
+
     Compute the transition band of an IIR filter, using the computed frequency response:
 
-    >>> from neurodsp.filt import design_iir_filter
+    >>> from neurodsp.filt.iir import design_iir_filter
     >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
     ...                                    f_range=(10, 20), butterworth_order=7)
     >>> f_db, db = compute_frequency_response(b_vals, a_vals, fs=500)
     >>> compute_transition_band(f_db, db, low=-20, high=-3)
     2.0
-
     """
 
     # This gets the indices of transitions to the values in searched for range
@@ -181,7 +192,6 @@ def compute_nyquist(fs):
 
     >>> compute_nyquist(fs=500)
     250.0
-
     """
 
     return fs / 2.
@@ -205,17 +215,15 @@ def remove_filter_edges(sig, filt_len):
 
     Examples
     --------
-    Remove the filter edges of a filtered signal:
+    Apply a filter and remove the filter edges of the filtered signal:
 
     >>> from neurodsp.filt.fir import design_fir_filter, apply_fir_filter
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     >>> filt_sig = apply_fir_filter(sig, filter_coefs)
     >>> filt_sig_no_edges = remove_filter_edges(filt_sig, filt_len=len(filter_coefs))
-
     """
 
     n_rmv = int(np.ceil(filt_len / 2))

--- a/neurodsp/plts/__init__.py
+++ b/neurodsp/plts/__init__.py
@@ -3,4 +3,5 @@
 from .time_series import plot_time_series, plot_bursts, plot_instantaneous_measure
 from .filt import plot_filter_properties, plot_frequency_response, plot_impulse_response
 from .rhythm import plot_swm_pattern, plot_lagged_coherence
-from .spectral import plot_power_spectra, plot_scv, plot_scv_rs_lines, plot_scv_rs_matrix, plot_spectral_hist
+from .spectral import (plot_power_spectra, plot_spectral_hist,
+                       plot_scv, plot_scv_rs_lines, plot_scv_rs_matrix)

--- a/neurodsp/plts/filt.py
+++ b/neurodsp/plts/filt.py
@@ -23,6 +23,18 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
         Sampling rate, in Hz.
     impulse_response : 1d array
         The impulse response of a filter. For an FIR filter, these are the filter coefficients.
+
+    Examples
+    --------
+    Plot a FIR bandpass filter:
+
+    >>> from neurodsp.filt import design_fir_filter
+    >>> from neurodsp.filt.utils import compute_frequency_response
+    >>> fs = 500
+    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
+    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs)
+    >>> plot_filter_properties(f_db, db, fs, filter_coefs)
+
     """
 
     fig, ax = plt.subplots(1, 2, figsize=(10, 5))
@@ -44,6 +56,18 @@ def plot_frequency_response(f_db, db, ax=None):
         Degree of attenuation for each frequency specified in f_db, in dB.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the frequency response of a FIR bandpass filter:
+
+    >>> from neurodsp.filt import design_fir_filter
+    >>> from neurodsp.filt.utils import compute_frequency_response
+    >>> fs = 500
+    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
+    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs)
+    >>> plot_frequency_response(f_db, db)
+
     """
 
     ax = check_ax(ax, (5, 5))
@@ -68,6 +92,17 @@ def plot_impulse_response(fs, impulse_response, ax=None):
         The impulse response of a filter.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the impulse response of a FIR bandpass filter:
+
+    >>> from neurodsp.filt import design_fir_filter
+    >>> from neurodsp.filt.utils import compute_frequency_response
+    >>> fs = 500
+    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
+    >>> plot_impulse_response(fs, filter_coefs)
+
     """
 
     ax = check_ax(ax, (5, 5))

--- a/neurodsp/plts/filt.py
+++ b/neurodsp/plts/filt.py
@@ -26,7 +26,7 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
 
     Examples
     --------
-    Plot a FIR bandpass filter:
+    Plot the properties of a FIR bandpass filter:
 
     >>> from neurodsp.filt import design_fir_filter
     >>> from neurodsp.filt.utils import compute_frequency_response
@@ -63,9 +63,8 @@ def plot_frequency_response(f_db, db, ax=None):
 
     >>> from neurodsp.filt import design_fir_filter
     >>> from neurodsp.filt.utils import compute_frequency_response
-    >>> fs = 500
-    >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
-    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs)
+    >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 40))
+    >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs=500)
     >>> plot_frequency_response(f_db, db)
 
     """

--- a/neurodsp/plts/filt.py
+++ b/neurodsp/plts/filt.py
@@ -26,7 +26,7 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
 
     Examples
     --------
-    Plot the properties of a FIR bandpass filter:
+    Plot the properties of an FIR bandpass filter:
 
     >>> from neurodsp.filt import design_fir_filter
     >>> from neurodsp.filt.utils import compute_frequency_response
@@ -34,7 +34,6 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
     >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
     >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs)
     >>> plot_filter_properties(f_db, db, fs, filter_coefs)
-
     """
 
     fig, ax = plt.subplots(1, 2, figsize=(10, 5))
@@ -59,14 +58,13 @@ def plot_frequency_response(f_db, db, ax=None):
 
     Examples
     --------
-    Plot the frequency response of a FIR bandpass filter:
+    Plot the frequency response of an FIR bandpass filter:
 
     >>> from neurodsp.filt import design_fir_filter
     >>> from neurodsp.filt.utils import compute_frequency_response
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 40))
     >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs=500)
     >>> plot_frequency_response(f_db, db)
-
     """
 
     ax = check_ax(ax, (5, 5))
@@ -94,14 +92,13 @@ def plot_impulse_response(fs, impulse_response, ax=None):
 
     Examples
     --------
-    Plot the impulse response of a FIR bandpass filter:
+    Plot the impulse response of an FIR bandpass filter:
 
     >>> from neurodsp.filt import design_fir_filter
     >>> from neurodsp.filt.utils import compute_frequency_response
     >>> fs = 500
     >>> filter_coefs = design_fir_filter(fs, pass_type='bandpass', f_range=(1, 40))
     >>> plot_impulse_response(fs, filter_coefs)
-
     """
 
     ax = check_ax(ax, (5, 5))

--- a/neurodsp/plts/rhythm.py
+++ b/neurodsp/plts/rhythm.py
@@ -19,6 +19,25 @@ def plot_swm_pattern(pattern, ax=None):
         The resulting average pattern from applying sliding window matching.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the average pattern from a sliding window matching analysis:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.rhythm import sliding_window_matching
+    >>>
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 20,
+    ...                                                            'enter_burst': .10,
+    ...                                                            'leave_burst': .15}},
+    ...                    component_variances=(0.001, 0.90))
+    >>> avg_window, _, _ = sliding_window_matching(sig, fs, win_len=0.05, win_spacing=0.5)
+    >>> plot_swm_pattern(avg_window)
+
     """
 
     ax = check_ax(ax, (4, 4))
@@ -43,6 +62,25 @@ def plot_lagged_coherence(freqs, lcs, ax=None):
         Lagged coherence values across the computed frequencies.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot lagged coherence from simulated data:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.rhythm import compute_lagged_coherence
+    >>>
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 20,
+    ...                                                            'enter_burst': .10,
+    ...                                                            'leave_burst': .15}},
+    ...                    component_variances=(0.001, 0.90))
+    >>> lag_coh_beta, freqs = compute_lagged_coherence(sig, fs, (5, 30), return_spectrum=True)
+    >>> plot_lagged_coherence(freqs, lag_coh_beta)
+
     """
 
     ax = check_ax(ax, (6, 3))

--- a/neurodsp/plts/rhythm.py
+++ b/neurodsp/plts/rhythm.py
@@ -26,16 +26,13 @@ def plot_swm_pattern(pattern, ax=None):
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.rhythm import sliding_window_matching
-    >>>
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 20,
     ...                                                            'enter_burst': .10,
     ...                                                            'leave_burst': .15}},
     ...                    component_variances=(0.001, 0.90))
-    >>> avg_window, _, _ = sliding_window_matching(sig, fs, win_len=0.05, win_spacing=0.5)
+    >>> avg_window, _, _ = sliding_window_matching(sig, fs=500, win_len=0.05, win_spacing=0.5)
     >>> plot_swm_pattern(avg_window)
 
     """
@@ -65,20 +62,18 @@ def plot_lagged_coherence(freqs, lcs, ax=None):
 
     Examples
     --------
-    Plot lagged coherence from simulated data:
+    Plot lagged coherence:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.rhythm import compute_lagged_coherence
-    >>>
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 20,
     ...                                                            'enter_burst': .10,
     ...                                                            'leave_burst': .15}},
     ...                    component_variances=(0.001, 0.90))
-    >>> lag_coh_beta, freqs = compute_lagged_coherence(sig, fs, (5, 30), return_spectrum=True)
+    >>> lag_coh_beta, freqs = compute_lagged_coherence(sig, fs=500, freqs=(15, 30),
+    ...                                                return_spectrum=True)
     >>> plot_lagged_coherence(freqs, lag_coh_beta)
 
     """

--- a/neurodsp/plts/rhythm.py
+++ b/neurodsp/plts/rhythm.py
@@ -27,14 +27,12 @@ def plot_swm_pattern(pattern, ax=None):
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.rhythm import sliding_window_matching
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 20,
-    ...                                                            'enter_burst': .10,
-    ...                                                            'leave_burst': .15}},
-    ...                    component_variances=(0.001, 0.90))
+    ...                    components={'sim_powerlaw': {'f_range': (2, None)},
+    ...                                'sim_bursty_oscillation': {'freq': 20,
+    ...                                                           'enter_burst': .25,
+    ...                                                           'leave_burst': .25}})
     >>> avg_window, _, _ = sliding_window_matching(sig, fs=500, win_len=0.05, win_spacing=0.5)
     >>> plot_swm_pattern(avg_window)
-
     """
 
     ax = check_ax(ax, (4, 4))
@@ -68,14 +66,12 @@ def plot_lagged_coherence(freqs, lcs, ax=None):
     >>> from neurodsp.rhythm import compute_lagged_coherence
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 20,
-    ...                                                            'enter_burst': .10,
-    ...                                                            'leave_burst': .15}},
-    ...                    component_variances=(0.001, 0.90))
-    >>> lag_coh_beta, freqs = compute_lagged_coherence(sig, fs=500, freqs=(15, 30),
-    ...                                                return_spectrum=True)
-    >>> plot_lagged_coherence(freqs, lag_coh_beta)
-
+    ...                                'sim_bursty_oscillation': {'freq': 20,
+    ...                                                           'enter_burst': .50,
+    ...                                                           'leave_burst': .25}})
+    >>> lag_cohs, freqs = compute_lagged_coherence(sig, fs=500, freqs=(5, 35),
+    ...                                            return_spectrum=True)
+    >>> plot_lagged_coherence(freqs, lag_cohs)
     """
 
     ax = check_ax(ax, (6, 3))

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -38,10 +38,9 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None):
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.01, 0.9))
+    ...                    component_variances=(0.5, 1.))
     >>> freqs, powers = compute_spectrum(sig, fs=500)
     >>> plot_power_spectra(freqs, powers)
-
     """
 
     ax = check_ax(ax, (6, 6))
@@ -85,12 +84,9 @@ def plot_scv(freqs, scv, ax=None):
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.01, 0.9))
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> freqs, scv = compute_scv(sig, fs=500)
     >>> plot_scv(freqs, scv)
-
     """
 
     ax = check_ax(ax, (5, 5))
@@ -122,13 +118,10 @@ def plot_scv_rs_lines(freqs, scv_rs, ax=None):
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv_rs
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.01, 0.9))
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, nperseg=500, method='bootstrap',
     ...                                        rs_params=(5, 200))
     >>> plot_scv_rs_lines(freqs, scv_rs)
-
     """
 
     ax = check_ax(ax, (8, 8))
@@ -163,14 +156,10 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs):
     >>> from neurodsp.spectral import compute_scv_rs
     >>> sig = sim_combined(n_seconds=100, fs=500,
     ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10,
-    ...                                                            'enter_burst':0.75}},
-    ...                    component_variances=(0.001, 0.9))
+    ...                                'sim_bursty_oscillation': {'freq': 10, 'enter_burst':0.75}})
     >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='rolling', rs_params=(10, 2))
+    >>> # Plot the computed scv, plotting frequencies up to 20 Hz (index of 21)
     >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])
-    >>> # Note that the first 21 values are indexed here and correspond to frequencies 0 through 20.
-    >>> #   This is done to highlight the simulated bursting at 10Hz.
-
     """
 
     fig, ax = plt.subplots(figsize=(10, 5))
@@ -210,18 +199,18 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None, sp
     >>> sig = sim_combined(n_seconds=100, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.01, 0.9))
-    >>> freqs, bins, spect_hist = compute_spectral_hist(sig, fs=500, nbins=40, f_range=(0, 80),
+    ...                    component_variances=(0.5, 1))
+    >>> freqs, bins, spect_hist = compute_spectral_hist(sig, fs=500, nbins=40, f_range=(1, 75),
     ...                                                 cut_pct=(0.1, 99.9))
     >>> plot_spectral_hist(freqs, bins, spect_hist)
-
     """
 
     # Automatically scale figure height based on number of bins
     plt.figure(figsize=(8, 12 * len(power_bins) / len(freqs)))
 
     # Plot histogram intensity as image and automatically adjust aspect ratio
-    plt.imshow(spectral_hist, extent=[freqs[0], freqs[-1], power_bins[0], power_bins[-1]], aspect='auto')
+    plt.imshow(spectral_hist, extent=[freqs[0], freqs[-1], power_bins[0], power_bins[-1]],
+               aspect='auto')
     plt.xlabel('Frequency (Hz)', fontsize=15)
     plt.ylabel('Log10 Power', fontsize=15)
     plt.colorbar(label='Probability')
@@ -229,7 +218,7 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None, sp
     plt.xlabel('Frequency (Hz)')
     plt.ylabel('Log10 Power')
 
-    # If a PSD is provided, plot over the histogram data
+    # If a power spectrum is provided, plot over the histogram data
     if spectrum is not None:
         plt_inds = np.logical_and(spectrum_freqs >= freqs[0], spectrum_freqs <= freqs[-1])
         plt.plot(spectrum_freqs[plt_inds], np.log10(spectrum[plt_inds]), color='w', alpha=0.8)

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -28,6 +28,21 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None):
         Colors to use to plot lines.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the power spectrum of a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_spectrum
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.01, 0.9))
+    >>> freqs, powers = compute_spectrum(sig, fs)
+    >>> plot_power_spectra(freqs, powers)
+
     """
 
     ax = check_ax(ax, (6, 6))
@@ -63,6 +78,21 @@ def plot_scv(freqs, scv, ax=None):
         Spectral coefficient of variation.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the power spectral coefficient of variation of a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_scv
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.01, 0.9))
+    >>> freqs, scv = compute_scv(sig, fs)
+    >>> plot_scv(freqs, scv)
+
     """
 
     ax = check_ax(ax, (5, 5))
@@ -86,6 +116,22 @@ def plot_scv_rs_lines(freqs, scv_rs, ax=None):
         Spectral coefficient of variation, from resampling procedure.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Plot the power spectral coefficient of variation of a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_scv_rs
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.01, 0.9))
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, nperseg=fs, method='bootstrap',
+    ...                                        rs_params=(5, 200))
+    >>> plot_scv_rs_lines(freqs, scv_rs)
+
     """
 
     ax = check_ax(ax, (8, 8))
@@ -111,6 +157,23 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs):
         Time indices.
     scv_rs : 1d array
         Spectral coefficient of variation, from resampling procedure.
+
+    Examples
+    --------
+    Plot a SCV matrix from a simulated signal with a high probability of bursting at 10Hz:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_scv_rs
+    >>> n_seconds = 100
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10,
+    ...                                                            'enter_burst':0.75}},
+    ...                    component_variances=(0.001, 0.9))
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, method='rolling', rs_params=(10, 2))
+    >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])
+
     """
 
     fig, ax = plt.subplots(figsize=(10, 5))
@@ -140,6 +203,22 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None, sp
         Frequency axis of the power spectrum to be plotted.
     spectrum : 1d array, optional
         Spectrum to be plotted over the histograms.
+
+    Examples
+    --------
+    Plot a spectral histogram for a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_spectral_hist
+    >>> n_seconds = 100
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.01, 0.9))
+    >>> freqs, bins, spect_hist = compute_spectral_hist(sig, fs, nbins=40, f_range=(0, 80),
+    ...                                                 cut_pct=(0.1, 99.9))
+    >>> plot_spectral_hist(freqs, bins, spect_hist)
+
     """
 
     # Automatically scale figure height based on number of bins

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -31,16 +31,15 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None):
 
     Examples
     --------
-    Plot the power spectrum of a simulated signal:
+    Plot a power spectrum:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_spectrum
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.01, 0.9))
-    >>> freqs, powers = compute_spectrum(sig, fs)
+    >>> freqs, powers = compute_spectrum(sig, fs=500)
     >>> plot_power_spectra(freqs, powers)
 
     """
@@ -81,16 +80,15 @@ def plot_scv(freqs, scv, ax=None):
 
     Examples
     --------
-    Plot the power spectral coefficient of variation of a simulated signal:
+    Plot the spectral coefficient of variation:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.01, 0.9))
-    >>> freqs, scv = compute_scv(sig, fs)
+    >>> freqs, scv = compute_scv(sig, fs=500)
     >>> plot_scv(freqs, scv)
 
     """
@@ -119,16 +117,15 @@ def plot_scv_rs_lines(freqs, scv_rs, ax=None):
 
     Examples
     --------
-    Plot the power spectral coefficient of variation of a simulated signal:
+    Plot the spectral coefficient of variation using a resampling method:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv_rs
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.01, 0.9))
-    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, nperseg=fs, method='bootstrap',
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, nperseg=fs, method='bootstrap',
     ...                                        rs_params=(5, 200))
     >>> plot_scv_rs_lines(freqs, scv_rs)
 
@@ -164,15 +161,15 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs):
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv_rs
-    >>> n_seconds = 100
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> sig = sim_combined(n_seconds=100, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10,
     ...                                                            'enter_burst':0.75}},
     ...                    component_variances=(0.001, 0.9))
-    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, method='rolling', rs_params=(10, 2))
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='rolling', rs_params=(10, 2))
     >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])
+    # Note that the first 21 values are indexed here and correspond to frequencies 0 through 20.
+    #   This is done to highlight the simulated bursting at 10Hz.
 
     """
 
@@ -206,16 +203,15 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None, sp
 
     Examples
     --------
-    Plot a spectral histogram for a simulated signal:
+    Plot a spectral histogram:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_spectral_hist
-    >>> n_seconds = 100
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=100, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.01, 0.9))
-    >>> freqs, bins, spect_hist = compute_spectral_hist(sig, fs, nbins=40, f_range=(0, 80),
+    >>> freqs, bins, spect_hist = compute_spectral_hist(sig, fs=500, nbins=40, f_range=(0, 80),
     ...                                                 cut_pct=(0.1, 99.9))
     >>> plot_spectral_hist(freqs, bins, spect_hist)
 

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -125,7 +125,7 @@ def plot_scv_rs_lines(freqs, scv_rs, ax=None):
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.01, 0.9))
-    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, nperseg=fs, method='bootstrap',
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, nperseg=500, method='bootstrap',
     ...                                        rs_params=(5, 200))
     >>> plot_scv_rs_lines(freqs, scv_rs)
 
@@ -168,8 +168,8 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs):
     ...                    component_variances=(0.001, 0.9))
     >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='rolling', rs_params=(10, 2))
     >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])
-    # Note that the first 21 values are indexed here and correspond to frequencies 0 through 20.
-    #   This is done to highlight the simulated bursting at 10Hz.
+    >>> # Note that the first 21 values are indexed here and correspond to frequencies 0 through 20.
+    >>> #   This is done to highlight the simulated bursting at 10Hz.
 
     """
 

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -37,12 +37,10 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None):
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.1, 0.9))
+    ...                    components={'sim_powerlaw': {'exponent': -1.5, 'f_range': (2, None)},
+    ...                                'sim_oscillation' : {'freq': 10}})
     >>> times = create_times(n_seconds=10, fs=500)
     >>> plot_time_series(times, sig)
-
     """
 
     ax = check_ax(ax, (15, 3))
@@ -87,17 +85,16 @@ def plot_instantaneous_measure(times, sigs, measure='phase', ax=None, **plt_kwar
 
     Examples
     --------
-    Create a instantaneous phase plot:
+    Create an instantaneous phase plot:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
-    >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}},
-    ...                    component_variances=(0.1, 0.9))
-    >>> times = create_times(n_seconds=10, fs=500)
-    >>> plot_instantaneous_measure(times, sig, measure='phase')
-
+    >>> from neurodsp.timefrequency import phase_by_time
+    >>> sig = sim_combined(n_seconds=2, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> pha = phase_by_time(sig, fs=500, f_range=(8, 12))
+    >>> times = create_times(n_seconds=2, fs=500)
+    >>> plot_instantaneous_measure(times, pha, measure='phase')
     """
 
     if measure not in ['phase', 'amplitude', 'frequency']:
@@ -132,7 +129,7 @@ def plot_bursts(times, sig, bursting, ax=None, **plt_kwargs):
 
     Examples
     --------
-    Plot bursts:
+    Create a plot of burst activity:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
@@ -141,10 +138,9 @@ def plot_bursts(times, sig, bursting, ax=None, **plt_kwargs):
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
-    >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(7, 12))
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(8, 12))
     >>> times = create_times(n_seconds=10, fs=500)
     >>> plot_bursts(times, sig, is_burst, labels=['Raw Data', 'Detected Bursts'])
-
     """
 
     ax = check_ax(ax, (15, 3))

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -32,17 +32,15 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None):
 
     Examples
     --------
-    Create a time series plot from a simulated signal:
+    Create a time series plot:
 
-    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
-    >>> set_random_seed(0)
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
-    >>> times = create_times(n_seconds, fs)
+    >>> times = create_times(n_seconds=10, fs=500)
     >>> plot_time_series(times, sig)
 
     """
@@ -89,16 +87,15 @@ def plot_instantaneous_measure(times, sigs, measure='phase', ax=None, **plt_kwar
 
     Examples
     --------
-    Create a instantaneous phase plot from a simulated signal:
+    Create a instantaneous phase plot:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
-    >>> times = create_times(n_seconds, fs)
+    >>> times = create_times(n_seconds, fs=500)
     >>> plot_instantaneous_measure(times, sig, measure='phase')
 
     """
@@ -135,19 +132,17 @@ def plot_bursts(times, sig, bursting, ax=None, **plt_kwargs):
 
     Examples
     --------
-    Plot bursts from a simulated signal:
+    Plot bursts:
 
-    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.utils import create_times
     >>> from neurodsp.burst import detect_bursts_dual_threshold
-    >>> set_random_seed(0)
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
-    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(7, 12))
-    >>> times = create_times(n_seconds, fs)
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(7, 12))
+    >>> times = create_times(n_seconds, fs=500)
     >>> plot_bursts(times, sig, is_burst, labels=['Raw Data', 'Detected Bursts'])
 
     """

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -29,6 +29,22 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None):
         Colors to use to plot lines.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
+
+    Examples
+    --------
+    Create a time series plot from a simulated signal:
+
+    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> from neurodsp.utils import create_times
+    >>> set_random_seed(0)
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.1, 0.9))
+    >>> times = create_times(n_seconds, fs)
+    >>> plot_time_series(times, sig)
+
     """
 
     ax = check_ax(ax, (15, 3))
@@ -70,6 +86,21 @@ def plot_instantaneous_measure(times, sigs, measure='phase', ax=None, **plt_kwar
         Figure axes upon which to plot.
     **plt_kwargs
         Keyword arguments to pass into `plot_time_series`.
+
+    Examples
+    --------
+    Create a instantaneous phase plot from a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.utils import create_times
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.1, 0.9))
+    >>> times = create_times(n_seconds, fs)
+    >>> plot_instantaneous_measure(times, sig, measure='phase')
+
     """
 
     if measure not in ['phase', 'amplitude', 'frequency']:
@@ -101,6 +132,24 @@ def plot_bursts(times, sig, bursting, ax=None, **plt_kwargs):
         Figure axes upon which to plot.
     **plt_kwargs
         Keyword arguments to pass into `plot_time_series`.
+
+    Examples
+    --------
+    Plot bursts from a simulated signal:
+
+    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> from neurodsp.utils import create_times
+    >>> from neurodsp.burst import detect_bursts_dual_threshold
+    >>> set_random_seed(0)
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}},
+    ...                    component_variances=(0.1, 0.9))
+    >>> is_burst = detect_bursts_dual_threshold(sig, fs, dual_thresh=(1, 2), f_range=(7, 12))
+    >>> times = create_times(n_seconds, fs)
+    >>> plot_bursts(times, sig, is_burst, labels=['Raw Data', 'Detected Bursts'])
+
     """
 
     ax = check_ax(ax, (15, 3))

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -95,7 +95,7 @@ def plot_instantaneous_measure(times, sigs, measure='phase', ax=None, **plt_kwar
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
-    >>> times = create_times(n_seconds, fs=500)
+    >>> times = create_times(n_seconds=10, fs=500)
     >>> plot_instantaneous_measure(times, sig, measure='phase')
 
     """
@@ -142,7 +142,7 @@ def plot_bursts(times, sig, bursting, ax=None, **plt_kwargs):
     ...                                'sim_bursty_oscillation' : {'freq': 10}},
     ...                    component_variances=(0.1, 0.9))
     >>> is_burst = detect_bursts_dual_threshold(sig, fs=500, dual_thresh=(1, 2), f_range=(7, 12))
-    >>> times = create_times(n_seconds, fs=500)
+    >>> times = create_times(n_seconds=10, fs=500)
     >>> plot_bursts(times, sig, is_burst, labels=['Raw Data', 'Detected Bursts'])
 
     """

--- a/neurodsp/rhythm/lc.py
+++ b/neurodsp/rhythm/lc.py
@@ -48,6 +48,24 @@ def compute_lagged_coherence(sig, fs, freqs, n_cycles=3, return_spectrum=False):
     .. [1] Fransen, A. M., van Ede, F., & Maris, E. (2015).
            Identifying neuronal oscillations using rhythmicity.
            Neuroimage, 118, 256-267. DOI: 10.1016/j.neuroimage.2015.06.003
+
+    Examples
+    --------
+    Compute lagged coherence for a simulated signal with beta oscillations:
+
+    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> set_random_seed(0)
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 20,
+    ...                                                            'enter_burst': .05,
+    ...                                                            'leave_burst': .10}},
+    ...                    component_variances=(0.001, 0.900))
+    >>> freqs = (1, 30)
+    >>> lag_coh_betas, freqs = compute_lagged_coherence(sig, fs, freqs, return_spectrum=True)
+
     """
 
     if isinstance(freqs, (tuple, list)):

--- a/neurodsp/rhythm/lc.py
+++ b/neurodsp/rhythm/lc.py
@@ -56,13 +56,10 @@ def compute_lagged_coherence(sig, fs, freqs, n_cycles=3, return_spectrum=False):
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 20,
-    ...                                                            'enter_burst': .05,
-    ...                                                            'leave_burst': .10}},
-    ...                    component_variances=(0.001, 0.900))
-    >>> lag_coh_betas, freqs = compute_lagged_coherence(sig, fs=500, freqs=(1, 30),
-    ...                                                 return_spectrum=True)
-
+    ...                                'sim_bursty_oscillation': {'freq': 20,
+    ...                                                           'enter_burst': .50,
+    ...                                                           'leave_burst': .25}})
+    >>> lag_cohs = compute_lagged_coherence(sig, fs=500, freqs=(5, 35))
     """
 
     if isinstance(freqs, (tuple, list)):

--- a/neurodsp/rhythm/lc.py
+++ b/neurodsp/rhythm/lc.py
@@ -53,18 +53,15 @@ def compute_lagged_coherence(sig, fs, freqs, n_cycles=3, return_spectrum=False):
     --------
     Compute lagged coherence for a simulated signal with beta oscillations:
 
-    >>> from neurodsp.sim import set_random_seed, sim_combined
-    >>> set_random_seed(0)
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> from neurodsp.sim import sim_combined
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 20,
     ...                                                            'enter_burst': .05,
     ...                                                            'leave_burst': .10}},
     ...                    component_variances=(0.001, 0.900))
-    >>> freqs = (1, 30)
-    >>> lag_coh_betas, freqs = compute_lagged_coherence(sig, fs, freqs, return_spectrum=True)
+    >>> lag_coh_betas, freqs = compute_lagged_coherence(sig, fs=500, freqs=(1, 30),
+    ...                                                 return_spectrum=True)
 
     """
 

--- a/neurodsp/rhythm/swm.py
+++ b/neurodsp/rhythm/swm.py
@@ -41,8 +41,9 @@ def sliding_window_matching(sig, fs, win_len, win_spacing, max_iterations=500,
     References
     ----------
     .. [1] Gips, B., Bahramisharif, A., Lowet, E., Roberts, M. J., de Weerd, P., Jensen, O., &
-           van der Eerden, J. (2017). Discovering recurring patterns in electrophysiological recordings.
-           Journal of Neuroscience Methods, 275, 66-79. DOI: 10.1016/j.jneumeth.2016.11.001
+           van der Eerden, J. (2017). Discovering recurring patterns in electrophysiological
+           recordings. Journal of Neuroscience Methods, 275, 66-79.
+           DOI: 10.1016/j.jneumeth.2016.11.001
            Matlab Code: https://github.com/bartgips/SWM
 
     Notes
@@ -54,19 +55,16 @@ def sliding_window_matching(sig, fs, win_len, win_spacing, max_iterations=500,
 
     Examples
     --------
-    Find reoccuring patterns using the sliding window matching algorithm in simulated beta
-    oscillations.
+    Search for reoccuring patterns using sliding window matching in a simulated beta signal:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 20,
-    ...                                                            'enter_burst': .05,
-    ...                                                            'leave_burst': .10}},
-    ...                    component_variances=(0.001, 0.900))
+    ...                    components={'sim_powerlaw': {'f_range': (2, None)},
+    ...                                'sim_bursty_oscillation': {'freq': 20,
+    ...                                                           'enter_burst': .25,
+    ...                                                           'leave_burst': .25}})
     >>> avg_window, window_starts, costs = sliding_window_matching(sig, fs=500, win_len=0.05,
     ...                                                            win_spacing=0.20)
-
     """
 
     # Compute window length and spacing in samples

--- a/neurodsp/rhythm/swm.py
+++ b/neurodsp/rhythm/swm.py
@@ -54,22 +54,18 @@ def sliding_window_matching(sig, fs, win_len, win_spacing, max_iterations=500,
 
     Examples
     --------
-    Simulated beta oscillations and find reoccuring patterns using the sliding window matching
-    algorithm.
+    Find reoccuring patterns using the sliding window matching algorithm in simulated beta
+    oscillations.
 
-    >>> from neurodsp.sim import set_random_seed, sim_combined
-    >>> set_random_seed(0)
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> from neurodsp.sim import sim_combined
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 20,
     ...                                                            'enter_burst': .05,
     ...                                                            'leave_burst': .10}},
     ...                    component_variances=(0.001, 0.900))
-    >>> win_len = 0.05
-    >>> win_spacing = 0.20
-    >>> avg_window, window_starts, costs = sliding_window_matching(sig, fs, win_len, win_spacing)
+    >>> avg_window, window_starts, costs = sliding_window_matching(sig, fs=500, win_len=0.05,
+    ...                                                            win_spacing=0.20)
 
     """
 

--- a/neurodsp/rhythm/swm.py
+++ b/neurodsp/rhythm/swm.py
@@ -51,6 +51,26 @@ def sliding_window_matching(sig, fs, win_len, win_spacing, max_iterations=500,
       not converge on a low frequency motif.
     - Parameters `win_len` and `win_spacing` should be chosen to be about the size of the
       motif of interest, and the N derived should be about the number of occurrences.
+
+    Examples
+    --------
+    Simulated beta oscillations and find reoccuring patterns using the sliding window matching
+    algorithm.
+
+    >>> from neurodsp.sim import set_random_seed, sim_combined
+    >>> set_random_seed(0)
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 20,
+    ...                                                            'enter_burst': .05,
+    ...                                                            'leave_burst': .10}},
+    ...                    component_variances=(0.001, 0.900))
+    >>> win_len = 0.05
+    >>> win_spacing = 0.20
+    >>> avg_window, window_starts, costs = sliding_window_matching(sig, fs, win_len, win_spacing)
+
     """
 
     # Compute window length and spacing in samples

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -49,7 +49,7 @@ def sim_poisson_pop(n_seconds, fs, n_neurons=1000, firing_rate=2):
 
     Examples
     --------
-    Simulated a Poisson population and return the signal:
+    Simulate a Poisson population:
 
     >>> sig = sim_poisson_pop(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2)
 
@@ -100,7 +100,7 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
     Examples
     --------
-    Simulate a synaptic current and return the signal:
+    Simulate a synaptic current:
 
     >>> sig = sim_synaptic_current(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2.,
     ...                            tau_r=0., tau_d=0.01, t_ker=None)
@@ -113,7 +113,7 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
     # Simulate an extra bit because the convolution will snip it.
     # Turn off normalization for this sig.
-    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate)
+    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate, mean=None, variance=None)
     ker = sim_synaptic_kernel(t_ker, fs, tau_r, tau_d)
     sig = np.convolve(sig, ker, 'valid')[:-1]
 
@@ -163,7 +163,7 @@ def sim_random_walk(n_seconds, fs, theta=1., mu=0., sigma=5.):
 
     Examples
     --------
-    Simulate a Ornstein-Uhlenbeck random walk and return the signal:
+    Simulate a Ornstein-Uhlenbeck random walk:
 
     >>> sig = sim_random_walk(n_seconds=1, fs=500, theta=1., mu=0., sigma=5.)
 
@@ -207,7 +207,7 @@ def sim_powerlaw(n_seconds, fs, exponent=-2.0, f_range=None, **filter_kwargs):
 
     Examples
     --------
-    Simulate a power law time series and return the signal:
+    Simulate a power law time series:
 
     >>> sig = sim_powerlaw(n_seconds=1, fs=500, exponent=-2.0, f_range=None)
 

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -46,6 +46,13 @@ def sim_poisson_pop(n_seconds, fs, n_neurons=1000, firing_rate=2):
 
     Note that the Gaussian approximation for a sum of Poisson processes is only
     a good approximation for large lambdas.
+
+    Examples
+    --------
+    Simulated a Poisson population and return the signal:
+
+    >>> sig = sim_poisson_pop(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2)
+
     """
 
     # Poisson population rate signal scales with # of neurons and individual rate
@@ -90,14 +97,23 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
     Notes
     -----
     The resulting signal is most similar to unsigned intracellular current or conductance change.
+
+    Examples
+    --------
+    Simulate a synaptic current and return the signal:
+
+    >>> sig = sim_synaptic_current(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2.,
+    ...                            tau_r=0., tau_d=0.01, t_ker=None)
+
     """
 
     # If not provided, compute t_ker as a function of decay time constant
     if t_ker is None:
         t_ker = 5. * tau_d
 
-    # Simulate an extra bit because the convolution will snip it. Turn off normalization for this sig
-    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate, mean=None, variance=None)
+    # Simulate an extra bit because the convolution will snip it.
+    # Turn off normalization for this sig.
+    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate)
     ker = sim_synaptic_kernel(t_ker, fs, tau_r, tau_d)
     sig = np.convolve(sig, ker, 'valid')[:-1]
 
@@ -144,6 +160,13 @@ def sim_random_walk(n_seconds, fs, theta=1., mu=0., sigma=5.):
     See the wikipedia page for the integral solution:
 
     https://en.wikipedia.org/wiki/Ornstein%E2%80%93Uhlenbeck_process#Formal_solution
+
+    Examples
+    --------
+    Simulate a Ornstein-Uhlenbeck random walk and return the signal:
+
+    >>> sig = sim_random_walk(n_seconds=1, fs=500, theta=1., mu=0., sigma=5.)
+
     """
 
     times = create_times(n_seconds, fs)
@@ -181,6 +204,13 @@ def sim_powerlaw(n_seconds, fs, exponent=-2.0, f_range=None, **filter_kwargs):
     -------
     sig: 1d array
         Time-series with the desired power law exponent.
+
+    Examples
+    --------
+    Simulate a power law time series and return the signal:
+
+    >>> sig = sim_powerlaw(n_seconds=1, fs=500, exponent=-2.0, f_range=None)
+
     """
 
     # Get the number of samples to simulate for the signal

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -52,7 +52,6 @@ def sim_poisson_pop(n_seconds, fs, n_neurons=1000, firing_rate=2):
     Simulate a Poisson population:
 
     >>> sig = sim_poisson_pop(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2)
-
     """
 
     # Poisson population rate signal scales with # of neurons and individual rate
@@ -100,20 +99,18 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
     Examples
     --------
-    Simulate a synaptic current:
+    Simulate a synaptic current signal:
 
-    >>> sig = sim_synaptic_current(n_seconds=1, fs=500, n_neurons=1000, firing_rate=2.,
-    ...                            tau_r=0., tau_d=0.01, t_ker=None)
-
+    >>> sig = sim_synaptic_current(n_seconds=1, fs=500)
     """
 
     # If not provided, compute t_ker as a function of decay time constant
     if t_ker is None:
         t_ker = 5. * tau_d
 
-    # Simulate an extra bit because the convolution will snip it.
-    # Turn off normalization for this sig.
-    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate, mean=None, variance=None)
+    # Simulate an extra bit because the convolution will trim & turn off normalization
+    sig = sim_poisson_pop((n_seconds + t_ker), fs, n_neurons, firing_rate,
+                          mean=None, variance=None)
     ker = sim_synaptic_kernel(t_ker, fs, tau_r, tau_d)
     sig = np.convolve(sig, ker, 'valid')[:-1]
 
@@ -165,8 +162,7 @@ def sim_random_walk(n_seconds, fs, theta=1., mu=0., sigma=5.):
     --------
     Simulate a Ornstein-Uhlenbeck random walk:
 
-    >>> sig = sim_random_walk(n_seconds=1, fs=500, theta=1., mu=0., sigma=5.)
-
+    >>> sig = sim_random_walk(n_seconds=1, fs=500, theta=1.)
     """
 
     times = create_times(n_seconds, fs)
@@ -207,10 +203,13 @@ def sim_powerlaw(n_seconds, fs, exponent=-2.0, f_range=None, **filter_kwargs):
 
     Examples
     --------
-    Simulate a power law time series:
+    Simulate a power law signal, with an exponent of -2 (brown noise):
 
-    >>> sig = sim_powerlaw(n_seconds=1, fs=500, exponent=-2.0, f_range=None)
+    >>> sig = sim_powerlaw(n_seconds=1, fs=500, exponent=-2.0)
 
+    Simulate a power law signal, with a highpass filter applied at 2 Hz:
+
+    >>> sig = sim_powerlaw(n_seconds=1, fs=500, exponent=-1.5, f_range=(2, None))
     """
 
     # Get the number of samples to simulate for the signal
@@ -259,7 +258,7 @@ def _create_powerlaw(n_samples, fs, exponent):
 
     Notes
     -----
-    This function create variable power law exponents by spectrally rotating white noise.
+    This function creates variable power law exponents by spectrally rotating white noise.
     """
 
     # Start with white noise signal, that we will rotate, in frequency space

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -35,13 +35,17 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
     --------
     Simulate a combined signal with an aperiodic and periodic component:
 
+    >>> n_seconds = 1
+    >>> fs = 500
     >>> sim_components = {'sim_powerlaw' : {'exponent' : -2}, 'sim_oscillation' : {'freq' : 10}}
-    >>> sim_combined(1, 500, sim_components)
+    >>> sig = sim_combined(n_seconds, fs, sim_components)
 
     Simulate a combined signal with multiple periodic components:
 
-    >>> sim_components = {'sim_powerlaw' : {'exponent' : -2}, 'sim_oscillation' : [{'freq' : 10}, {'freq' : 20}]}
-    >>> sim_combined(1, 500, sim_components)
+    >>> sim_components = {'sim_powerlaw' : {'exponent' : -2},
+    ...                   'sim_oscillation' : [{'freq' : 10}, {'freq' : 20}]}
+    >>> sig = sim_combined(n_seconds, fs, sim_components)
+
     """
 
     # Check how simulation components are specified, in terms of number of parameter sets

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -35,17 +35,20 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
     --------
     Simulate a combined signal with an aperiodic and periodic component:
 
-    >>> n_seconds = 1
-    >>> fs = 500
-    >>> sim_components = {'sim_powerlaw' : {'exponent' : -2}, 'sim_oscillation' : {'freq' : 10}}
-    >>> sig = sim_combined(n_seconds, fs, sim_components)
+    >>> sim_components = {'sim_powerlaw': {'exponent' : -2}, 'sim_oscillation': {'freq' : 10}}
+    >>> sig = sim_combined(n_seconds=1, fs=500, components=sim_components)
 
     Simulate a combined signal with multiple periodic components:
 
-    >>> sim_components = {'sim_powerlaw' : {'exponent' : -2},
-    ...                   'sim_oscillation' : [{'freq' : 10}, {'freq' : 20}]}
-    >>> sig = sim_combined(n_seconds, fs, sim_components)
+    >>> sim_components = {'sim_powerlaw': {'exponent' : -2},
+    ...                   'sim_oscillation': [{'freq' : 10}, {'freq' : 20}]}
+    >>> sig = sim_combined(n_seconds=1, fs=500, components=sim_components)
 
+    Simulate a combined signal with unequal variance for the different components:
+
+    >>> sig = sim_combined(n_seconds=1, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq' : 10}},
+    ...                    component_variances=[0.25, 0.75])
     """
 
     # Check how simulation components are specified, in terms of number of parameter sets

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -30,6 +30,13 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', **cycle_params):
     -------
     sig : 1d array
         Simulated oscillation.
+
+    Examples
+    --------
+    Simulate an sine oscillation at 5 hz and return the signal:
+
+    >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=5, cycle='sine')
+
     """
 
     # Figure out how many cycles are needed for the signal, & length of each cycle
@@ -82,6 +89,14 @@ def sim_bursty_oscillation(n_seconds, fs, freq, enter_burst=.2, leave_burst=.2,
 
     If the cycle length does not fit evenly into the simulated data length,
     then the last few samples will be non-oscillating.
+
+    Examples
+    --------
+    Simulate a bursy oscilation and return the signal:
+
+    >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=5, enter_burst=.2,
+    ...                              leave_burst=.2, cycle='sine')
+
     """
 
     # Determine number of samples & cycles

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -33,7 +33,7 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', **cycle_params):
 
     Examples
     --------
-    Simulate an sine oscillation at 5 hz and return the signal:
+    Simulate a sine oscillation at 5 hz:
 
     >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=5, cycle='sine')
 
@@ -92,7 +92,7 @@ def sim_bursty_oscillation(n_seconds, fs, freq, enter_burst=.2, leave_burst=.2,
 
     Examples
     --------
-    Simulate a bursy oscilation and return the signal:
+    Simulate a bursty oscillation:
 
     >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=5, enter_burst=.2,
     ...                              leave_burst=.2, cycle='sine')

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -33,10 +33,9 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', **cycle_params):
 
     Examples
     --------
-    Simulate a sine oscillation at 5 hz:
+    Simulate a continuous oscillation at 5 hz:
 
-    >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=5, cycle='sine')
-
+    >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=5)
     """
 
     # Figure out how many cycles are needed for the signal, & length of each cycle
@@ -92,11 +91,17 @@ def sim_bursty_oscillation(n_seconds, fs, freq, enter_burst=.2, leave_burst=.2,
 
     Examples
     --------
-    Simulate a bursty oscillation:
+    Simulate a bursty oscillation, with a low probability of bursting:
 
-    >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=5, enter_burst=.2,
-    ...                              leave_burst=.2, cycle='sine')
+    >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=5, enter_burst=0.2, leave_burst=0.8)
 
+    Simulate a bursty oscillation, with a high probability of bursting:
+
+    >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=15, enter_burst=0.8, leave_burst=0.4)
+
+    Simulate a bursty oscillation, of sawtooth waves:
+
+    >>> sig = sim_bursty_oscillation(n_seconds=10, fs=500, freq=10, cycle='sawtooth', width=0.3)
     """
 
     # Determine number of samples & cycles

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -45,10 +45,13 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
 
     Examples
     --------
-    Simulate a single 2 hz sine cycle, where frequency = 1 / n_seconds:
+    Simulate a half second sinusoidal cycle, corresponding to a 2 Hz cycle (frequency=1/n_seconds):
 
     >>> cycle = sim_cycle(n_seconds=0.5, fs=500, cycle_type='sine')
 
+    Simulate a sawtooth cycle, corresponding to a 10 Hz cycle:
+
+    >>> cycle = sim_cycle(n_seconds=0.1, fs=500, cycle_type='sawtooth', width=0.3)
     """
 
     if cycle_type not in ['sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp']:
@@ -99,10 +102,9 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
 
     Examples
     --------
-    Simulate a 2 hz asymetric sine cycle:
+    Simulate a 2 Hz asymmetric sine cycle:
 
     >>> cycle = sim_asine_cycle(n_seconds=0.5, fs=500, rdsym=0.75)
-
     """
 
     # Determine number of samples in rise and decay periods
@@ -148,10 +150,13 @@ def sim_synaptic_kernel(n_seconds, fs, tau_r, tau_d):
 
     Examples
     --------
-    Simulate an alpha synapse kernel:
+    Simulate an alpha synaptic kernel:
 
     >>> kernel = sim_synaptic_kernel(n_seconds=1, fs=500, tau_r=0.25, tau_d=0.25)
 
+    Simulate a double exponential synaptic kernel:
+
+    >>> kernel = sim_synaptic_kernel(n_seconds=1, fs=500, tau_r=0.1, tau_d=0.3)
     """
 
     # NOTE: sometimes n_seconds is not exact, resulting in a slightly longer or
@@ -202,7 +207,6 @@ def create_cycle_time(n_seconds, fs):
     Create time indices, in radians, for a single cycle:
 
     >>> indices = create_cycle_time(n_seconds=1, fs=500)
-
     """
 
     return 2 * np.pi * 1 / n_seconds * (np.arange(fs * n_seconds) / fs)

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -45,7 +45,7 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
 
     Examples
     --------
-    Simulate and return a single 2 hz sine cycle, where frequency = 1 / n_seconds:
+    Simulate a single 2 hz sine cycle, where frequency = 1 / n_seconds:
 
     >>> cycle = sim_cycle(n_seconds=0.5, fs=500, cycle_type='sine')
 
@@ -99,7 +99,7 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
 
     Examples
     --------
-    Simulate and return a single 2 hz asymetric sine cycle:
+    Simulate a 2 hz asymetric sine cycle:
 
     >>> cycle = sim_asine_cycle(n_seconds=0.5, fs=500, rdsym=0.75)
 
@@ -148,7 +148,7 @@ def sim_synaptic_kernel(n_seconds, fs, tau_r, tau_d):
 
     Examples
     --------
-    Simulate and return an alpha synapse kernel:
+    Simulate an alpha synapse kernel:
 
     >>> kernel = sim_synaptic_kernel(n_seconds=1, fs=500, tau_r=0.25, tau_d=0.25)
 
@@ -199,7 +199,7 @@ def create_cycle_time(n_seconds, fs):
 
     Examples
     --------
-    Create and return time indices, in radians, for a single cycle:
+    Create time indices, in radians, for a single cycle:
 
     >>> indices = create_cycle_time(n_seconds=1, fs=500)
 

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -42,6 +42,13 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
     -------
     cycle: 1d array
         Simulated cycle.
+
+    Examples
+    --------
+    Simulate and return a single 2 hz sine cycle, where frequency = 1 / n_seconds:
+
+    >>> cycle = sim_cycle(n_seconds=0.5, fs=500, cycle_type='sine')
+
     """
 
     if cycle_type not in ['sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp']:
@@ -89,6 +96,13 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
     -------
     cycle : 1d array
         Simulated asymmetric cycle.
+
+    Examples
+    --------
+    Simulate and return a single 2 hz asymetric sine cycle:
+
+    >>> cycle = sim_asine_cycle(n_seconds=0.5, fs=500, rdsym=0.75)
+
     """
 
     # Determine number of samples in rise and decay periods
@@ -131,6 +145,13 @@ def sim_synaptic_kernel(n_seconds, fs, tau_r, tau_d):
     - tau_r == tau_d      : alpha synapse
     - tau_r = 0           : instantaneous rise, with single exponential decay
     - tau_r != tau_d != 0 : double-exponential, with exponential rise and decay
+
+    Examples
+    --------
+    Simulate and return an alpha synapse kernel:
+
+    >>> kernel = sim_synaptic_kernel(n_seconds=1, fs=500, tau_r=0.25, tau_d=0.25)
+
     """
 
     # NOTE: sometimes n_seconds is not exact, resulting in a slightly longer or
@@ -175,6 +196,13 @@ def create_cycle_time(n_seconds, fs):
     -------
     1d array
         Time indices.
+
+    Examples
+    --------
+    Create and return time indices, in radians, for a single cycle:
+
+    >>> indices = create_cycle_time(n_seconds=1, fs=500)
+
     """
 
     return 2 * np.pi * 1 / n_seconds * (np.arange(fs * n_seconds) / fs)

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -42,6 +42,18 @@ def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
         Frequencies at which the measure was calculated.
     spectrum : 1d or 2d array
         Power spectral density.
+
+    Examples
+    --------
+    Compute the PSD of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum(sig, fs)
+
     """
 
     if method == 'welch':
@@ -82,6 +94,18 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
         Frequencies at which the measure was calculated.
     spectrum : 1d or 2d array
         Power spectral density.
+
+    Examples
+    --------
+    Compute the PSD of a simulated time series using wavelets:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_wavelet(sig, fs, [1, 30])
+
     """
 
     if isinstance(freqs, (tuple, list)):
@@ -130,6 +154,18 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
         Frequencies at which the measure was calculated.
     spectrum : 1d or 2d array
         Power spectral density.
+
+    Examples
+    --------
+    Compute the PSD of a simulated time series using Welch's method:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_welch(sig, fs)
+
     """
 
     # Calculate the short time Fourier transform with signal.spectrogram
@@ -171,6 +207,18 @@ def compute_spectrum_medfilt(sig, fs, filt_len=1., f_range=None):
         Frequencies at which the measure was calculated.
     spectrum : 1d or 2d array
         Power spectral density.
+
+    Examples
+    --------
+    Compute the PSD of a simulated time series as a smoothed FFT:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_medfilt(sig, fs)
+
     """
 
     # Take the positive half of the spectrum since it's symmetrical

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -160,7 +160,7 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
-    ...                                 sim_bursty_oscillation' : {'freq': 10}})
+    ...                                'sim_bursty_oscillation': {'freq': 10}})
     >>> freqs, spec = compute_spectrum_welch(sig, fs=500)
 
     """

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -49,10 +49,8 @@ def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum(sig, fs=500)
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs, spectrum = compute_spectrum(sig, fs=500)
     """
 
     if method == 'welch':
@@ -100,10 +98,8 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum_wavelet(sig, fs=500, freqs=[1, 30])
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs, spectrum = compute_spectrum_wavelet(sig, fs=500, freqs=[1, 30])
     """
 
     if isinstance(freqs, (tuple, list)):
@@ -159,10 +155,8 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation': {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq': 10}})
     >>> freqs, spec = compute_spectrum_welch(sig, fs=500)
-
     """
 
     # Calculate the short time Fourier transform with signal.spectrogram
@@ -211,13 +205,11 @@ def compute_spectrum_medfilt(sig, fs, filt_len=1., f_range=None):
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> freqs, spec = compute_spectrum_medfilt(sig, fs=500)
-
     """
 
-    # Take the positive half of the spectrum since it's symmetrical
+    # Take the positive half of the spectrum, since it's symmetrical
     ft = np.fft.fft(sig)[:int(np.ceil(len(sig) / 2.))]
     freqs = np.fft.fftfreq(len(sig), 1. / fs)[:int(np.ceil(len(sig) / 2.))]
 

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -45,14 +45,13 @@ def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
 
     Examples
     --------
-    Compute the PSD of a simulated time series:
+    Compute the power spectrum of a simulated time series:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum(sig, fs=500)
 
     """
 
@@ -97,14 +96,13 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
 
     Examples
     --------
-    Compute the PSD of a simulated time series using wavelets:
+    Compute the power spectrum of a simulated time series using wavelets:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum_wavelet(sig, fs, [1, 30])
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_wavelet(sig, fs=500, freqs=[1, 30])
 
     """
 
@@ -157,14 +155,13 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
 
     Examples
     --------
-    Compute the PSD of a simulated time series using Welch's method:
+    Compute the power spectrum of a simulated time series using Welch's method:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum_welch(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                 sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_welch(sig, fs=500)
 
     """
 
@@ -210,14 +207,13 @@ def compute_spectrum_medfilt(sig, fs, filt_len=1., f_range=None):
 
     Examples
     --------
-    Compute the PSD of a simulated time series as a smoothed FFT:
+    Compute the power spectrum of a simulated time series as a smoothed FFT:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum_medfilt(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum_medfilt(sig, fs=500)
 
     """
 

--- a/neurodsp/spectral/utils.py
+++ b/neurodsp/spectral/utils.py
@@ -28,6 +28,20 @@ def trim_spectrum(freqs, power_spectra, f_range):
     -----
     This function extracts frequency ranges >= f_low and <= f_high.
     It does not round to below or above f_low and f_high, respectively.
+
+    Examples
+    --------
+    Trim the PSD of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_spectrum
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum(sig, fs)
+    >>> freqs_ext, spec_ext = trim_spectrum(freqs, spec, [1, 30])
+
     """
 
     # Create mask to index only requested frequencies
@@ -52,7 +66,7 @@ def rotate_powerlaw(freqs, spectrum, delta_exponent, f_rotation=1):
         Power spectrum to be rotated.
     delta_exponent : float
         Change in power law exponent to be applied.
-        Positive is counterclockwise rotation (flatten), negative is clockwise rotation (steepen).
+        Positive is clockwise rotation (steepen), negative is counter clockwise rotation (flatten).
     f_rotation : float, optional, default: 1
         Frequency at which to rotate the spectrum, where power is unchanged by the rotation, in Hz.
         This only matters if not further normalizing signal variance.
@@ -61,6 +75,20 @@ def rotate_powerlaw(freqs, spectrum, delta_exponent, f_rotation=1):
     -------
     rotated_spectrum : 1d array
         Rotated spectrum.
+
+    Examples
+    --------
+    Rotate and flatten a simulated powerspectrum:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.spectral import compute_spectrum
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum(sig, fs)
+    >>> rotated_spectrum = rotate_powerlaw(freqs, spec, -2)
+
     """
 
     if freqs[0] == 0:

--- a/neurodsp/spectral/utils.py
+++ b/neurodsp/spectral/utils.py
@@ -36,11 +36,9 @@ def trim_spectrum(freqs, power_spectra, f_range):
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_spectrum
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum(sig, fs=500)
-    >>> freqs_ext, spec_ext = trim_spectrum(freqs, spec, [1, 30])
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs, spectrum = compute_spectrum(sig, fs=500)
+    >>> freqs_ext, spec_ext = trim_spectrum(freqs, spectrum, [1, 30])
     """
 
     # Create mask to index only requested frequencies
@@ -77,18 +75,14 @@ def rotate_powerlaw(freqs, spectrum, delta_exponent, f_rotation=1):
 
     Examples
     --------
-    Rotate and flatten a simulated powerspectrum:
+    Rotate a power spectrum, calculated on simualated data:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_spectrum
-    >>> fs = 500
-    >>> n_seconds=10
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_powerlaw': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum(sig, fs)
-    >>> rotated_spectrum = rotate_powerlaw(freqs, spec, -2)
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs, spectrum = compute_spectrum(sig, fs=500)
+    >>> rotated_spectrum = rotate_powerlaw(freqs, spectrum, -1)
     """
 
     if freqs[0] == 0:

--- a/neurodsp/spectral/utils.py
+++ b/neurodsp/spectral/utils.py
@@ -31,15 +31,14 @@ def trim_spectrum(freqs, power_spectra, f_range):
 
     Examples
     --------
-    Trim the PSD of a simulated time series:
+    Trim the power spectrum of a simulated time series:
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_spectrum
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, spec = compute_spectrum(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, spec = compute_spectrum(sig, fs=500)
     >>> freqs_ext, spec_ext = trim_spectrum(freqs, spec, [1, 30])
 
     """
@@ -84,8 +83,9 @@ def rotate_powerlaw(freqs, spectrum, delta_exponent, f_rotation=1):
     >>> from neurodsp.spectral import compute_spectrum
     >>> fs = 500
     >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
     >>> freqs, spec = compute_spectrum(sig, fs)
     >>> rotated_spectrum = rotate_powerlaw(freqs, spec, -2)
 

--- a/neurodsp/spectral/variance.py
+++ b/neurodsp/spectral/variance.py
@@ -44,6 +44,18 @@ def compute_scv(sig, fs, window='hann', nperseg=None, noverlap=0, outlier_pct=No
     Notes
     -----
     White noise should have a SCV of 1 at all frequencies.
+
+    Examples
+    --------
+    Compute the spectral coefficient of variation of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, scv = compute_scv(sig, fs)
+
     """
 
     # Compute spectrogram of data
@@ -61,7 +73,7 @@ def compute_scv(sig, fs, window='hann', nperseg=None, noverlap=0, outlier_pct=No
 @multidim(select=[0, 1])
 def compute_scv_rs(sig, fs, window='hann', nperseg=None, noverlap=0,
                    method='bootstrap', rs_params=None):
-    """Compute a resampled version of the the spectral coefficient of variation (SCV).
+    """Compute a resampled version of the spectral coefficient of variation (SCV).
 
     Parameters
     -----------
@@ -112,6 +124,18 @@ def compute_scv_rs(sig, fs, window='hann', nperseg=None, noverlap=0,
 
     Resampling can be done either randomly (method='bootstrap') or in a time-stepped
     manner (method='rolling').
+
+    Examples
+    --------
+    Compute the resampled spectral coefficient of variation of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, method='bootstrap')
+
     """
 
     # Compute spectrogram of data
@@ -199,6 +223,18 @@ def compute_spectral_hist(sig, fs, window='hann', nperseg=None, noverlap=None,
     Notes
     -----
     Histogram bins are the same for every frequency, evenly spacing the global min & max power.
+
+    Examples
+    --------
+    Compute the log10 power distribution of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, power_bins, spectral_hist = compute_spectral_hist(sig, fs)
+
     """
 
     # Compute spectrogram of data

--- a/neurodsp/spectral/variance.py
+++ b/neurodsp/spectral/variance.py
@@ -127,14 +127,13 @@ def compute_scv_rs(sig, fs, window='hann', nperseg=None, noverlap=0,
 
     Examples
     --------
-    Compute the resampled spectral coefficient of variation of a simulated time series:
+    Compute the resampled spectral coefficient of variation:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs, method='bootstrap')
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='bootstrap')
 
     """
 
@@ -226,14 +225,13 @@ def compute_spectral_hist(sig, fs, window='hann', nperseg=None, noverlap=None,
 
     Examples
     --------
-    Compute the log10 power distribution of a simulated time series:
+    Compute the log10 power distribution:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, power_bins, spectral_hist = compute_spectral_hist(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation': {'freq': 10}})
+    >>> freqs, power_bins, spectral_hist = compute_spectral_hist(sig, fs=500)
 
     """
 

--- a/neurodsp/spectral/variance.py
+++ b/neurodsp/spectral/variance.py
@@ -50,12 +50,9 @@ def compute_scv(sig, fs, window='hann', nperseg=None, noverlap=0, outlier_pct=No
     Compute the spectral coefficient of variation of a simulated time series:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> freqs, scv = compute_scv(sig, fs)
-
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs, scv = compute_scv(sig, fs=500)
     """
 
     # Compute spectrogram of data
@@ -127,14 +124,12 @@ def compute_scv_rs(sig, fs, window='hann', nperseg=None, noverlap=0,
 
     Examples
     --------
-    Compute the resampled spectral coefficient of variation:
+    Compute the resampled spectral coefficient of variation, using the bootstrap method:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='bootstrap')
-
     """
 
     # Compute spectrogram of data
@@ -225,14 +220,12 @@ def compute_spectral_hist(sig, fs, window='hann', nperseg=None, noverlap=None,
 
     Examples
     --------
-    Compute the log10 power distribution:
+    Compute the distribution of power, which is the spectral histogram:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation': {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq': 10}})
     >>> freqs, power_bins, spectral_hist = compute_spectral_hist(sig, fs=500)
-
     """
 
     # Compute spectrogram of data

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -30,14 +30,12 @@ def robust_hilbert(sig, increase_n=False):
 
     Examples
     --------
-    Compute a Hilbert transform:
+    Compute a Hilbert transform of a signal, using zero padding:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> sig_hilb = robust_hilbert(sig)
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq': 10}})
+    >>> sig_hilb = robust_hilbert(sig, increase_n=True)
     """
 
     # Extract the signal that is not nan
@@ -86,13 +84,12 @@ def phase_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous phase:
+    Compute the instantaneous phase, for the alpha range:
 
     >>> from neurodsp.sim import sim_combined
-    >>> sig = sim_combined(n_seconds=10, fs=500, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation': {'freq': 10}})
-    >>> pha = phase_by_time(sig, fs=500)
-
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq': 10}})
+    >>> pha = phase_by_time(sig, fs=500, f_range=(8, 12))
     """
 
     if f_range:
@@ -136,14 +133,12 @@ def amp_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous amplitude:
+    Compute the instantaneous amplitude, for the alpha range:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> amp = amp_by_time(sig, fs=500)
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> amp = amp_by_time(sig, fs=500, f_range=(8, 12))
     """
 
     if f_range:
@@ -191,14 +186,12 @@ def freq_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous frequency:
+    Compute the instantaneous frequency, for the alpha range:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> instant_freq = freq_by_time(sig, fs=500)
-
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> instant_freq = freq_by_time(sig, fs=500, f_range=(8, 12))
     """
 
     pha = phase_by_time(sig, fs, f_range, hilbert_increase_n,

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -27,6 +27,18 @@ def robust_hilbert(sig, increase_n=False):
     -------
     sig_hilb : 1d array
         The Hilbert transform of the input signal.
+
+    Examples
+    --------
+    Simulated a signal and compute the Hilbert transform:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> sig_hilb = robust_hilbert(sig)
+
     """
 
     # Extract the signal that is not nan
@@ -72,6 +84,18 @@ def phase_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
     -------
     pha : 1d array
         Instantaneous phase time series.
+
+    Examples
+    --------
+    Compute the instantaneous phase of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation': {'freq': 10}})
+    >>> pha = phase_by_time(sig, fs)
+
     """
 
     if f_range:
@@ -112,6 +136,18 @@ def amp_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
     -------
     amp : 1d array
         Instantaneous amplitude time series.
+
+    Examples
+    --------
+    Compute the instantaneous amplitude of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> amp = amp_by_time(sig, fs)
+
     """
 
     if f_range:
@@ -156,6 +192,18 @@ def freq_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
     Notes
     -----
     This function assumes monotonic phase, so phase slips will be processed as high frequencies.
+
+    Examples
+    --------
+    Compute the instantaneous frequency of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> instant_freq = freq_by_time(sig, fs)
+
     """
 
     pha = phase_by_time(sig, fs, f_range, hilbert_increase_n,

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -30,13 +30,12 @@ def robust_hilbert(sig, increase_n=False):
 
     Examples
     --------
-    Simulated a signal and compute the Hilbert transform:
+    Compute a Hilbert transform:
 
     >>> from neurodsp.sim import sim_combined
-    >>> n_seconds = 10
-    >>> fs = 500
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
     >>> sig_hilb = robust_hilbert(sig)
 
     """
@@ -87,14 +86,12 @@ def phase_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous phase of a simulated time series:
+    Compute the instantaneous phase:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
+    >>> sig = sim_combined(n_seconds=10, fs=500, components={'sim_synaptic_current': {},
     ...                                               'sim_bursty_oscillation': {'freq': 10}})
-    >>> pha = phase_by_time(sig, fs)
+    >>> pha = phase_by_time(sig, fs=500)
 
     """
 
@@ -139,14 +136,13 @@ def amp_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous amplitude of a simulated time series:
+    Compute the instantaneous amplitude:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> amp = amp_by_time(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> amp = amp_by_time(sig, fs=500)
 
     """
 
@@ -195,14 +191,13 @@ def freq_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
 
     Examples
     --------
-    Compute the instantaneous frequency of a simulated time series:
+    Compute the instantaneous frequency:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds = 10
-    >>> sig = sim_combined(n_seconds, fs, components={'sim_synaptic_current': {},
-    ...                                               'sim_bursty_oscillation' : {'freq': 10}})
-    >>> instant_freq = freq_by_time(sig, fs)
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> instant_freq = freq_by_time(sig, fs=500)
 
     """
 

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -36,15 +36,13 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
 
     Examples
     --------
-    Compute the Morlet wavewlet time-frequency representation of a simulated signal:
+    Compute a Morlet wavelet time-frequency representation:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> mwt = compute_wavelet_transform(sig, fs, [1, 30])
+    >>> mwt = compute_wavelet_transform(sig, fs=500, freqs=[1, 30])
 
     """
 
@@ -97,15 +95,13 @@ def convolve_wavelet(sig, fs, freq, n_cycles=7, scaling=0.5, wavelet_len=None, n
 
     Examples
     --------
-    Convolve a simulated signal with a complex wavelet and return a complex time series:
+    Convolve a complex wavelet with a simulated signal:
 
     >>> from neurodsp.sim import sim_combined
-    >>> fs = 500
-    >>> n_seconds=10
-    >>> sig = sim_combined(n_seconds, fs,
+    >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_synaptic_current': {},
     ...                                'sim_bursty_oscillation' : {'freq': 10}})
-    >>> cts = convolve_wavelet(sig, fs, 10)
+    >>> cts = convolve_wavelet(sig, fs=500, freq=10)
 
     """
 

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -33,6 +33,19 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
     -------
     mwt : 2d array
         Time frequency representation of the input signal.
+
+    Examples
+    --------
+    Compute the Morlet wavewlet time-frequency representation of a simulated signal:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> mwt = compute_wavelet_transform(sig, fs, [1, 30])
+
     """
 
     if isinstance(freqs, (tuple, list)):
@@ -81,6 +94,19 @@ def convolve_wavelet(sig, fs, freq, n_cycles=7, scaling=0.5, wavelet_len=None, n
     * The real part of the returned array is the filtered signal.
     * Taking np.abs() of output gives the analytic amplitude.
     * Taking np.angle() of output gives the analytic phase.
+
+    Examples
+    --------
+    Convolve a simulated signal with a complex wavelet and return a complex time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> fs = 500
+    >>> n_seconds=10
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_synaptic_current': {},
+    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    >>> cts = convolve_wavelet(sig, fs, 10)
+
     """
 
     if wavelet_len is None:

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -36,14 +36,12 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
 
     Examples
     --------
-    Compute a Morlet wavelet time-frequency representation:
+    Compute a Morlet wavelet time-frequency representation of a signal:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> mwt = compute_wavelet_transform(sig, fs=500, freqs=[1, 30])
-
     """
 
     if isinstance(freqs, (tuple, list)):
@@ -99,10 +97,8 @@ def convolve_wavelet(sig, fs, freq, n_cycles=7, scaling=0.5, wavelet_len=None, n
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation' : {'freq': 10}})
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> cts = convolve_wavelet(sig, fs=500, freq=10)
-
     """
 
     if wavelet_len is None:

--- a/neurodsp/utils/decorators.py
+++ b/neurodsp/utils/decorators.py
@@ -59,8 +59,10 @@ def multidim(select=[]):
 
                 if isinstance(outs[0], tuple):
 
-                    # Collect together associated outputs from each, in case there are multiple outputs
-                    out = [np.stack([dat[n_out] for dat in outs]) for n_out in range(len(outs[0]))]
+                    # Collect together associated outputs from each,
+                    #   in case there are multiple outputs
+                    out = [np.stack([dat[n_out] for dat in outs]) \
+                        for n_out in range(len(outs[0]))]
 
                     # Sub-select single instance of collection for requested outputs
                     out = [dat[0] if ind in select else dat for ind, dat in enumerate(out)]

--- a/summary.sh
+++ b/summary.sh
@@ -17,6 +17,10 @@ printf "\n\n\n RUN TESTS & TEST COVERAGE: \n"
 coverage run --source neurodsp  -m py.test
 coverage report
 
+# Check doctests - runs doctests with pytest, skipping normal tests
+printf "\n\n\nCHECK DOCTEST EXAMPLES: \n"
+pytest --doctest-modules --ignore=neurodsp/tests neurodsp
+
 # Run pylint and print summary
 printf "\n\n\n RUN PYLINT ACROSS MODULE: \n"
 pylint neurodsp --ignore tests -> _lint.txt


### PR DESCRIPTION
Related to #180. All functions with API docs now have examples in the docstrings. All doctests pass. Running doctest has been added to summary.sh. A few docstring typos have been fixed with this PR as well.