### PR TITLE
[FIX] Allow line styles when plotting.

### DIFF
--- a/neurodsp/plts/settings.py
+++ b/neurodsp/plts/settings.py
@@ -11,7 +11,7 @@ LINE_STYLE_ARGS = ['alpha', 'lw', 'linewidth', 'ls', 'linestyle']
 # Custom style arguments are those that are custom-handled by the plot style function
 CUSTOM_STYLE_ARGS = ['title_fontsize', 'label_size', 'tick_labelsize',
                      'legend_size', 'legend_loc']
-STYLERS = ['plot_styler', 'line_styler', 'custom_styler']
+STYLERS = ['axis_styler', 'line_styler', 'custom_styler']
 STYLE_ARGS = AXIS_STYLE_ARGS + LINE_STYLE_ARGS + CUSTOM_STYLE_ARGS + STYLERS
 
 ## Define default values for aesthetic

--- a/neurodsp/plts/settings.py
+++ b/neurodsp/plts/settings.py
@@ -1,0 +1,22 @@
+"""Default settings for plots."""
+
+###################################################################################################
+###################################################################################################
+
+## Define collections of style arguments
+# Plot style arguments are those that can be defined on an axis object
+PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
+# Line style arguments are those that can be defined on a line object
+LINE_STYLE_ARGS = ['alpha', 'lw', 'linewidth', 'ls', 'linestyle']
+# Custom style arguments are those that are customly handled by the plot style function
+CUSTOM_STYLE_ARGS = ['title_fontsize', 'label_size', 'tick_labelsize'
+                      'legend_size', 'legend_loc']
+STYLE_ARGS = PLOT_STYLE_ARGS + LINE_STYLE_ARGS + CUSTOM_STYLE_ARGS
+
+## Define default values for aesthetic
+# These are all custom style arguments
+TITLE_FONTSIZE = 20
+LABEL_SIZE = 16
+TICK_LABELSIZE = 16
+LEGEND_SIZE = 12
+LEGEND_LOC = 'best'

--- a/neurodsp/plts/settings.py
+++ b/neurodsp/plts/settings.py
@@ -5,13 +5,14 @@
 
 ## Define collections of style arguments
 # Plot style arguments are those that can be defined on an axis object
-PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
+AXIS_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
 # Line style arguments are those that can be defined on a line object
 LINE_STYLE_ARGS = ['alpha', 'lw', 'linewidth', 'ls', 'linestyle']
 # Custom style arguments are those that are custom-handled by the plot style function
 CUSTOM_STYLE_ARGS = ['title_fontsize', 'label_size', 'tick_labelsize',
                      'legend_size', 'legend_loc']
-STYLE_ARGS = PLOT_STYLE_ARGS + LINE_STYLE_ARGS + CUSTOM_STYLE_ARGS
+STYLERS = ['plot_styler', 'line_styler', 'custom_styler']
+STYLE_ARGS = AXIS_STYLE_ARGS + LINE_STYLE_ARGS + CUSTOM_STYLE_ARGS + STYLERS
 
 ## Define default values for aesthetic
 # These are all custom style arguments

--- a/neurodsp/plts/settings.py
+++ b/neurodsp/plts/settings.py
@@ -8,9 +8,9 @@
 PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
 # Line style arguments are those that can be defined on a line object
 LINE_STYLE_ARGS = ['alpha', 'lw', 'linewidth', 'ls', 'linestyle']
-# Custom style arguments are those that are customly handled by the plot style function
-CUSTOM_STYLE_ARGS = ['title_fontsize', 'label_size', 'tick_labelsize'
-                      'legend_size', 'legend_loc']
+# Custom style arguments are those that are custom-handled by the plot style function
+CUSTOM_STYLE_ARGS = ['title_fontsize', 'label_size', 'tick_labelsize',
+                     'legend_size', 'legend_loc']
 STYLE_ARGS = PLOT_STYLE_ARGS + LINE_STYLE_ARGS + CUSTOM_STYLE_ARGS
 
 ## Define default values for aesthetic

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -211,8 +211,6 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None, sp
     # Plot histogram intensity as image and automatically adjust aspect ratio
     plt.imshow(spectral_hist, extent=[freqs[0], freqs[-1], power_bins[0], power_bins[-1]],
                aspect='auto')
-    plt.xlabel('Frequency (Hz)', fontsize=15)
-    plt.ylabel('Log10 Power', fontsize=15)
     plt.colorbar(label='Probability')
 
     plt.xlabel('Frequency (Hz)')

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -1,6 +1,6 @@
 """Plotting functions for neurodsp.spectral."""
 
-from itertools import repeat
+from itertools import repeat, cycle
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/neurodsp/plts/style.py
+++ b/neurodsp/plts/style.py
@@ -7,7 +7,8 @@ import matplotlib.pyplot as plt
 ###################################################################################################
 ###################################################################################################
 
-PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim', 'alpha', 'lw']
+PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
+LINE_STYLE_ARGS = ['alpha', 'lw']
 
 def plot_style(ax, **kwargs):
     """Define plot style."""
@@ -40,6 +41,7 @@ def style_plot(func, *args, **kwargs):
         # Grab a custom style function, if provided, and grab any provided style arguments
         style_func = kwargs.pop('plot_style', plot_style)
         style_kwargs = {key : kwargs.pop(key) for key in PLOT_STYLE_ARGS if key in kwargs}
+        line_kwargs = {key : kwargs.pop(key) for key in LINE_STYLE_ARGS if key in kwargs}
 
         # Create the plot
         func(*args, **kwargs)
@@ -47,5 +49,28 @@ def style_plot(func, *args, **kwargs):
         # Get plot axis, if a specific one was provided, or just grab current and apply style
         cur_ax = kwargs['ax'] if 'ax' in kwargs and kwargs['ax'] is not None else plt.gca()
         style_func(cur_ax, **style_kwargs)
+
+        # Apply line styles
+        for line_style in LINE_STYLE_ARGS:
+
+            # Ensure argument is valid
+            if line_style in line_kwargs.keys() and line_kwargs[line_style] is not None:
+
+                # Change style line-by-line
+                for idx, line in enumerate(cur_ax.lines):
+
+                    if line_style == 'lw':
+                        try:
+                            line.set_linewidth(line_kwargs[line_style][idx])
+                        except TypeError:
+                            # If an arg is not iterable, all lines will have the same style.
+                            line.set_linewidth(line_kwargs[line_style])
+
+                    if line_style == 'alpha':
+                        try:
+                            line.set_alpha(line_kwargs[line_style][idx])
+                        except TypeError:
+                            # If an arg is not iterable, all lines will have the same style.
+                            line.set_alpha(line_kwargs[line_style])
 
     return decorated

--- a/neurodsp/plts/style.py
+++ b/neurodsp/plts/style.py
@@ -5,12 +5,12 @@ from functools import wraps
 
 import matplotlib.pyplot as plt
 
-###################################################################################################
-###################################################################################################
+from neurodsp.plts.settings import PLOT_STYLE_ARGS, LINE_STYLE_ARGS, STYLE_ARGS
+from neurodsp.plts.settings import (LABEL_SIZE, LEGEND_SIZE, LEGEND_LOC,
+                                    TICK_LABELSIZE, TITLE_FONTSIZE)
 
-PLOT_STYLE_ARGS = ['title', 'xlabel', 'ylabel', 'xlim', 'ylim']
-LINE_STYLE_ARGS = ['alpha', 'lw', 'linewidth', 'ls', 'linestyle']
-STYLE_ARGS = PLOT_STYLE_ARGS + LINE_STYLE_ARGS
+###################################################################################################
+###################################################################################################
 
 def plot_style(ax, **kwargs):
     """Define plot style."""
@@ -29,18 +29,23 @@ def plot_style(ax, **kwargs):
         for idx, line in enumerate(ax.lines):
             line.set(**{style : next(values)})
 
-    # Aesthetics and axis labels
-    ax.xaxis.label.set_size(16)
-    ax.yaxis.label.set_size(16)
-    ax.tick_params(axis='both', which='major', labelsize=16)
+    # If a title was provided, update the size
+    if ax.get_title():
+        ax.title.set_size(kwargs.pop('title_fontsize', TITLE_FONTSIZE))
+
+    # Settings for the axis labels
+    label_size = kwargs.pop('label_size', LABEL_SIZE)
+    ax.xaxis.label.set_size(label_size)
+    ax.yaxis.label.set_size(label_size)
+
+    # Settings for the axis ticks
+    ax.tick_params(axis='both', which='major',
+                   labelsize=kwargs.pop('tick_labelsize', TICK_LABELSIZE))
 
     # If labels were provided, add a legend
     if ax.get_legend_handles_labels()[0]:
-        ax.legend(prop={'size': 12}, loc='best')
-
-    # If a title was provided, update the size
-    if ax.get_title():
-        ax.title.set_size(20)
+        ax.legend(prop={'size': kwargs.pop('legend_size', LEGEND_SIZE)},
+                  loc=kwargs.pop('legend_loc', LEGEND_LOC))
 
     plt.tight_layout()
 

--- a/neurodsp/plts/style.py
+++ b/neurodsp/plts/style.py
@@ -34,7 +34,7 @@ def plot_style(ax, **kwargs):
         # Values should be either a single value, for all lines, or a list, of a value per line
         #   This line checks type, and makes a cycle-able / loop-able object out of the values
         values = cycle([value] if isinstance(value, (int, float, str)) else value)
-        for idx, line in enumerate(ax.lines):
+        for line in ax.lines:
             line.set(**{style : next(values)})
 
     # If a title was provided, update the size
@@ -64,7 +64,7 @@ def style_plot(func, *args, **kwargs):
     Parameters
     ----------
     func : callable
-        The plotting function to create a plot
+        The plotting function for creating a plot.
     *args, **kwargs
         Arguments & keyword arguments.
         These should include any arguments for the plot, and those for applying plot style.

--- a/neurodsp/plts/style.py
+++ b/neurodsp/plts/style.py
@@ -1,4 +1,4 @@
-"""Style helpers and utilities for plots."""
+"""Functions and utilities to apply aesthetic styling to plots."""
 
 from itertools import cycle
 from functools import wraps
@@ -13,7 +13,15 @@ from neurodsp.plts.settings import (LABEL_SIZE, LEGEND_SIZE, LEGEND_LOC,
 ###################################################################################################
 
 def plot_style(ax, **kwargs):
-    """Define plot style."""
+    """Apply plot style to a figure axis.
+
+    Parameters
+    ----------
+    ax : matplotlib.Axes
+        Figure axes to apply style to.
+    **kwargs
+        Keyword arguments that define plot style to apply.
+    """
 
     # Apply any provided plot style arguments
     plot_kwargs = {key : val for key, val in kwargs.items() if key in PLOT_STYLE_ARGS}
@@ -51,7 +59,29 @@ def plot_style(ax, **kwargs):
 
 
 def style_plot(func, *args, **kwargs):
-    """Decorator function to apply a plot style function, after plot generation."""
+    """Decorator function to apply a plot style function, after plot generation.
+
+    Parameters
+    ----------
+    func : callable
+        The plotting function to create a plot
+    *args, **kwargs
+        Arguments & keyword arguments.
+        These should include any arguments for the plot, and those for applying plot style.
+
+    Notes
+    -----
+    This is a decorate, for plot, functions that functions roughly as:
+
+    - catching all inputs that relate to plot style
+    - create a plot, using the passed in plotting function & passing in all non-style arguments
+    - passing the style related arguments into a `plot_style` function
+
+    This function itself does not apply create any plots or apply any styling itself.
+
+    By default, this function applies styling with the `plot_style` function. Custom
+    functions for applying style can be passed in using `plot_style` as a keyword argument.
+    """
 
     @wraps(func)
     def decorated(*args, **kwargs):

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -25,7 +25,7 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None):
         Time series to plot.
     labels : list of str, optional
         Labels for each time series.
-    cols : str or list of str
+    colors : str or list of str
         Colors to use to plot lines.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.

--- a/neurodsp/tests/test_plts_rhythm.py
+++ b/neurodsp/tests/test_plts_rhythm.py
@@ -12,11 +12,11 @@ from neurodsp.plts.rhythm import *
 @plot_test
 def tests_plot_swm_pattern():
 
-    dat = np.arange(0, 2, 0.1)
-    plot_swm_pattern(dat)
+    data = np.arange(0, 2, 0.1)
+    plot_swm_pattern(data)
 
 @plot_test
 def test_plot_lagged_coherence():
 
-    dat = np.arange(0, 2, 0.1)
-    plot_lagged_coherence(dat, dat)
+    data = np.arange(0, 2, 0.1)
+    plot_lagged_coherence(data, data)

--- a/neurodsp/tests/test_plts_spectral.py
+++ b/neurodsp/tests/test_plts_spectral.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from neurodsp.spectral.variance import compute_spectral_hist
+from neurodsp.spectral.power import compute_spectrum
 from neurodsp.tests.utils import plot_test
 
 from neurodsp.plts.spectral import *
@@ -15,7 +16,7 @@ def test_plot_power_spectra():
 
     freqs, powers = np.array([1, 2, 3, 4]), np.array([10, 20, 30, 40])
     plot_power_spectra(freqs, powers)
-    plot_power_spectra([freqs, freqs], [powers, powers])
+    plot_power_spectra([freqs, freqs], [powers, powers], labels=['a', 'b'], colors=['k', 'r'])
 
 @plot_test
 def test_plot_scv():
@@ -40,4 +41,6 @@ def test_plot_scv_rs_matrix():
 def test_plot_spectral_hist(tsig):
 
     freqs, power_bins, spectral_hist = compute_spectral_hist(tsig, fs=1000)
-    plot_spectral_hist(freqs, power_bins, spectral_hist)
+    spectrum_freqs, spectrum = compute_spectrum(tsig, fs=1000)
+    plot_spectral_hist(freqs, power_bins, spectral_hist,
+                       spectrum=spectrum, spectrum_freqs=spectrum_freqs)

--- a/neurodsp/tests/test_plts_style.py
+++ b/neurodsp/tests/test_plts_style.py
@@ -1,0 +1,92 @@
+"""Test plot style related functionality."""
+
+import matplotlib.pyplot as plt
+
+from neurodsp.plts.settings import TITLE_FONTSIZE
+
+from neurodsp.tests.utils import plot_test
+
+from neurodsp.plts.style import *
+
+###################################################################################################
+###################################################################################################
+
+def test_apply_axis_style():
+
+    _, ax = plt.subplots()
+
+    title = 'Ploty McPlotface'
+    xlim = (1.0, 10.0)
+    ylabel = 'Line Value'
+
+    apply_axis_style(ax, title=title, xlim=xlim, ylabel=ylabel)
+
+    assert ax.get_title() == title
+    assert ax.get_xlim() == xlim
+    assert ax.get_ylabel() == ylabel
+
+def test_apply_line_style():
+
+    # Check applying style to one line
+    _, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+
+    lw = 4
+    apply_line_style(ax, lw=lw)
+
+    assert ax.get_lines()[0].get_lw() == lw
+
+    # Check applying style across multiple lines
+    _, ax = plt.subplots()
+    ax.plot([1, 2], [[3, 4], [5, 6]])
+
+    alphas = [0.5, 0.75]
+    apply_line_style(ax, alpha=alphas)
+
+    for line, alpha in zip(ax.get_lines(), alphas):
+        assert line.get_alpha() == alpha
+
+def test_apply_custom_style():
+
+    _, ax = plt.subplots()
+    ax.set_title('placeholder')
+
+    # Test simple application of custom plot style
+    apply_custom_style(ax)
+    assert ax.title.get_size() == TITLE_FONTSIZE
+
+    # Test adding input parameters to custom plot style
+    new_title_fontsize = 15.0
+    apply_custom_style(ax, title_fontsize=new_title_fontsize)
+    assert ax.title.get_size() == new_title_fontsize
+
+def test_plot_style():
+
+    _, ax = plt.subplots()
+
+    def my_custom_styler(ax, **kwargs):
+        ax.set_title('DATA!')
+
+    # Apply plot style using all defaults
+    plot_style(ax)
+
+    # Apply plot style passing in a styler
+    plot_style(ax, custom_styler=my_custom_styler)
+
+@plot_test
+def test_style_plot():
+
+    @style_plot
+    def example_plot():
+        plt.plot([1, 2], [3, 4])
+
+    def my_plot_style(ax, **kwargs):
+        ax.set_title('Custom!')
+
+    # Test with applying default custom styling
+    lw = 5
+    title = 'Science.'
+    example_plot(title=title, lw=lw)
+
+    # Test with passing in own plot_style function
+    example_plot(plot_style=my_plot_style)

--- a/neurodsp/tests/test_plts_time_series.py
+++ b/neurodsp/tests/test_plts_time_series.py
@@ -1,5 +1,7 @@
 """Test time series plots."""
 
+import tempfile
+
 from pytest import raises
 
 from neurodsp.tests.utils import plot_test
@@ -16,7 +18,10 @@ def test_plot_time_series(tsig):
     plot_time_series(times, tsig)
 
     tsig_rev = tsig[::-1]
-    plot_time_series(times, [tsig, tsig_rev], lw=[1, 2], alpha=[1, 0.5])
+    with tempfile.NamedTemporaryFile(mode='w+') as f:
+        plot_time_series(times, [tsig, tsig_rev], lw=[1, 2], alpha=[1, 0.5],
+                         labels=['signal', 'signal reversed'], colors=['k', 'r'],
+                         save_fig=True, file_name=f.name)
 
 @plot_test
 def test_plot_instantaneous_measure(tsig):

--- a/neurodsp/tests/test_plts_time_series.py
+++ b/neurodsp/tests/test_plts_time_series.py
@@ -1,7 +1,5 @@
 """Test time series plots."""
 
-import tempfile
-
 from pytest import raises
 
 from neurodsp.tests.utils import plot_test
@@ -15,18 +13,19 @@ from neurodsp.plts.time_series import *
 def test_plot_time_series(tsig):
 
     times = np.arange(0, len(tsig), 1)
+
+    # Run single time series plot
     plot_time_series(times, tsig)
 
-    tsig_rev = tsig[::-1]
-    with tempfile.NamedTemporaryFile(mode='w+') as f:
-        plot_time_series(times, [tsig, tsig_rev], lw=[1, 2], alpha=[1, 0.5],
-                         labels=['signal', 'signal reversed'], colors=['k', 'r'],
-                         save_fig=True, file_name=f.name)
+    # Run multi time series plot, with colors & labels
+    plot_time_series(times, [tsig, tsig[::-1]],
+                     labels=['signal', 'signal reversed'], colors=['k', 'r'])
 
 @plot_test
 def test_plot_instantaneous_measure(tsig):
 
     times = np.arange(0, len(tsig), 1)
+
     plot_instantaneous_measure(times, tsig, 'phase')
     plot_instantaneous_measure(times, tsig, 'amplitude')
     plot_instantaneous_measure(times, tsig, 'frequency')
@@ -40,4 +39,5 @@ def test_plot_bursts(tsig):
 
     times = np.arange(0, len(tsig), 1)
     bursts = np.array([True] * len(tsig))
+
     plot_bursts(times, tsig, bursts)

--- a/neurodsp/tests/test_plts_time_series.py
+++ b/neurodsp/tests/test_plts_time_series.py
@@ -15,6 +15,9 @@ def test_plot_time_series(tsig):
     times = np.arange(0, len(tsig), 1)
     plot_time_series(times, tsig)
 
+    tsig_rev = tsig[::-1]
+    plot_time_series(times, [tsig, tsig_rev], lw=[1, 2], alpha=[1, 0.5])
+
 @plot_test
 def test_plot_instantaneous_measure(tsig):
 

--- a/neurodsp/tests/test_plts_utils.py
+++ b/neurodsp/tests/test_plts_utils.py
@@ -1,0 +1,35 @@
+"""Test plot utilities."""
+
+import os
+import tempfile
+
+from neurodsp.plts.utils import *
+
+###################################################################################################
+###################################################################################################
+
+def test_check_ax():
+
+    # Check running will None Input
+    ax = check_ax(None)
+
+    # Check running with pre-created axis
+    _, ax = plt.subplots()
+    nax = check_ax(ax)
+    assert nax == ax
+
+    # Check creating figure of a particular size
+    figsize = [5, 5]
+    ax = check_ax(None, figsize=figsize)
+    fig = plt.gcf()
+    assert list(fig.get_size_inches()) == figsize
+
+def test_savefig():
+
+    @savefig
+    def example_plot():
+        plt.plot([1, 2], [3, 4])
+
+    with tempfile.NamedTemporaryFile(mode='w+') as file:
+        example_plot(save_fig=True, file_name=file.name)
+        assert os.path.exists(file.name)


### PR DESCRIPTION
Before,  'alpha' and 'lw' had no effect when plotting with `plot_time_series`, and this PR fixes this. A list can be passed for either line style argument, and the style will be applied to each line in the corresponding order. For example, in `plot_time_series(times, [sig_a, sig_b], lw=[1, 5])`, a linewidth of 1 will be applied to sig_a and a width of 5 for sig_b. Alternatively a single value can be passed and all lines will have the same style.

Here is a [notebook](https://github.com/ryanhammonds/neurodsp/blob/explores/line_styles.ipynb) that has an example of the change.