### PR TITLE
[ENH] Color cycling defaults

### DIFF
--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -60,8 +60,8 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
         colors = ['k', 'r']
     colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
 
-    for time, sig, label in zip(times, sigs, labels):
-        ax.plot(time, sig, color=next(colors), label=label)
+    for time, sig, color, label in zip(times, sigs, colors, labels):
+        ax.plot(time, sig, color=color, label=label)
 
     ax.set_xlabel('Time (s)')
     ax.set_ylabel('Voltage (uV)')

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -55,17 +55,14 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
     else:
         labels = repeat(labels)
 
-    if colors is not None:
-        colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
-    elif len(sigs) <= 2:
+    # If not provided, default colors for up to two signals to be black & red
+    if not colors and len(sigs) <= 2:
         colors = cycle(['k', 'r'])
+    else:
+        colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
 
     for time, sig, label in zip(times, sigs, labels):
-
-        if colors is not None:
-            ax.plot(time, sig, next(colors), label=label)
-        else:
-            ax.plot(time, sig, label=label)
+        ax.plot(time, sig, color=next(colors), label=label)
 
     ax.set_xlabel('Time (s)')
     ax.set_ylabel('Voltage (uV)')

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -57,11 +57,15 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
 
     if colors is not None:
         colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
-    else:
-        colors = cycle(['k', 'r', 'b', 'g', 'm', 'c'])
+    elif len(sigs) <= 2:
+        colors = cycle(['k', 'r'])
 
-    for time, sig, color, label in zip(times, sigs, colors, labels):
-        ax.plot(time, sig, color, label=label)
+    for time, sig, label in zip(times, sigs, labels):
+
+        if colors is not None:
+            ax.plot(time, sig, next(colors), label=label)
+        else:
+            ax.plot(time, sig, label=label)
 
     ax.set_xlabel('Time (s)')
     ax.set_ylabel('Voltage (uV)')

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -57,9 +57,8 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
 
     # If not provided, default colors for up to two signals to be black & red
     if not colors and len(sigs) <= 2:
-        colors = cycle(['k', 'r'])
-    else:
-        colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
+        colors = ['k', 'r']
+    colors = repeat(colors) if not isinstance(colors, list) else cycle(colors)
 
     for time, sig, label in zip(times, sigs, labels):
         ax.plot(time, sig, color=next(colors), label=label)


### PR DESCRIPTION
This changes the color default in `plot_time_series` to 'k' and 'r' for 1 or 2 signals. If more than two signals are given, then mpl's default color cycle is used. Users can still overwrite these defaults.