### PR TITLE
[BUG] - Fix numerical instabilities for IIR filters

### DIFF
--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -133,15 +133,6 @@ def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range,
     >>> passes = check_filter_properties(filter_coefs, 1, fs, pass_type, f_range)
     Transition bandwidth is 0.5 Hz.
     Pass/stop bandwidth is 24.0 Hz.
-
-    Check the properties of an IIR filter:
-
-    >>> from neurodsp.filt.iir import design_iir_filter
-    >>> fs, pass_type, f_range, order = 500, 'bandstop', (55, 65), 7
-    >>> b_vals, a_vals = design_iir_filter(fs, pass_type, f_range, order)
-    >>> passes = check_filter_properties(b_vals, a_vals, fs, pass_type, f_range)
-    Transition bandwidth is 1.5 Hz.
-    Pass/stop bandwidth is 10.0 Hz.
     """
 
     # Import utility functions inside function to avoid circular imports
@@ -153,6 +144,92 @@ def check_filter_properties(b_vals, a_vals, fs, pass_type, f_range,
 
     # Compute the frequency response
     f_db, db = compute_frequency_response(b_vals, a_vals, fs)
+
+    # Check that frequency response goes below transition level (has significant attenuation)
+    if np.min(db) >= transitions[0]:
+        passes = False
+        warn('The filter attenuation never goes below {} dB.'\
+             'Increase filter length.'.format(transitions[0]))
+        # If there is no attenuation, cannot calculate bands, so return here
+        return passes
+
+    # Check that both sides of a bandpass have significant attenuation
+    if pass_type == 'bandpass':
+        if db[0] >= transitions[0] or db[-1] >= transitions[0]:
+            passes = False
+            warn('The low or high frequency stopband never gets attenuated by'\
+                 'more than {} dB. Increase filter length.'.format(abs(transitions[0])))
+
+    # Compute pass & transition bandwidth
+    pass_bw = compute_pass_band(fs, pass_type, f_range)
+    transition_bw = compute_transition_band(f_db, db, transitions[0], transitions[1])
+
+    # Raise warning if transition bandwidth is too high
+    if transition_bw > pass_bw:
+        passes = False
+        warn('Transition bandwidth is  {:.1f}  Hz. This is greater than the desired'\
+             'pass/stop bandwidth of  {:.1f} Hz'.format(transition_bw, pass_bw))
+
+    # Print out transition bandwidth and pass bandwidth to the user
+    if verbose:
+        print('Transition bandwidth is {:.1f} Hz.'.format(transition_bw))
+        print('Pass/stop bandwidth is {:.1f} Hz.'.format(pass_bw))
+
+    return passes
+
+def sos_check_filter_properties(sos, fs, pass_type, f_range,
+                                transitions=(-20, -3), verbose=True):
+    """Check a filters properties, including pass band and transition band.
+
+    Parameters
+    ----------
+    sos : 2d array of shape (n, 6)
+        Second order series coefficients for an IIR filter.
+    fs : float
+        Sampling rate, in Hz.
+    pass_type : {'bandpass', 'bandstop', 'lowpass', 'highpass'}
+        Which kind of filter to apply:
+
+        * 'bandpass': apply a bandpass filter
+        * 'bandstop': apply a bandstop (notch) filter
+        * 'lowpass': apply a lowpass filter
+        * 'highpass' : apply a highpass filter
+    f_range : tuple of (float, float) or float
+        Cutoff frequency(ies) used for filter, specified as f_lo & f_hi.
+        For 'bandpass' & 'bandstop', must be a tuple.
+        For 'lowpass' or 'highpass', can be a float that specifies pass frequency, or can be
+        a tuple and is assumed to be (None, f_hi) for 'lowpass', and (f_lo, None) for 'highpass'.
+    transitions : tuple of (float, float), optional, default: (-20, -3)
+        Cutoffs, in dB, that define the transition band.
+    verbose : bool, optional, default: True
+        Whether to print out transition and pass bands.
+
+    Returns
+    -------
+    passes : bool
+        Whether all the checks pass. False if one or more checks fail.
+
+    Examples
+    --------
+    Check the properties of an IIR filter:
+
+    >>> from neurodsp.filt.iir import design_iir_filter
+    >>> fs, pass_type, f_range, order = 500, 'bandstop', (55, 65), 7
+    >>> sos = design_iir_filter(fs, pass_type, f_range, order)
+    >>> passes = sos_check_filter_properties(sos, fs, pass_type, f_range)
+    Transition bandwidth is 1.5 Hz.
+    Pass/stop bandwidth is 10.0 Hz.
+    """
+
+    # Import utility functions inside function to avoid circular imports
+    from neurodsp.filt.utils import (sos_compute_frequency_response,
+                                     compute_pass_band, compute_transition_band)
+
+    # Initialize variable to keep track if all checks pass
+    passes = True
+
+    # Compute the frequency response
+    f_db, db = sos_compute_frequency_response(sos, fs)
 
     # Check that frequency response goes below transition level (has significant attenuation)
     if np.min(db) >= transitions[0]:

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -174,15 +174,14 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
     f_lo, f_hi = check_filter_definition(pass_type, f_range)
     filt_len = compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles, n_seconds)
 
-    f_nyq = compute_nyquist(fs)
     if pass_type == 'bandpass':
-        filter_coefs = firwin(filt_len, (f_lo, f_hi), pass_zero=False, nyq=f_nyq)
+        filter_coefs = firwin(filt_len, (f_lo, f_hi), pass_zero=False, fs=fs)
     elif pass_type == 'bandstop':
-        filter_coefs = firwin(filt_len, (f_lo, f_hi), nyq=f_nyq)
+        filter_coefs = firwin(filt_len, (f_lo, f_hi), fs=fs)
     elif pass_type == 'highpass':
-        filter_coefs = firwin(filt_len, f_lo, pass_zero=False, nyq=f_nyq)
+        filter_coefs = firwin(filt_len, f_lo, pass_zero=False, fs=fs)
     elif pass_type == 'lowpass':
-        filter_coefs = firwin(filt_len, f_hi, nyq=f_nyq)
+        filter_coefs = firwin(filt_len, f_hi, fs=fs)
 
     return filter_coefs
 

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -6,7 +6,7 @@ from scipy.signal import firwin
 from neurodsp.utils import remove_nans, restore_nans
 from neurodsp.utils.decorators import multidim
 from neurodsp.plts.filt import plot_filter_properties
-from neurodsp.filt.utils import compute_nyquist, compute_frequency_response, remove_filter_edges
+from neurodsp.filt.utils import compute_frequency_response, remove_filter_edges
 from neurodsp.filt.checks import (check_filter_definition, check_filter_properties,
                                   check_filter_length)
 

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -2,11 +2,11 @@
 
 from warnings import warn
 
-from scipy.signal import butter, filtfilt
+from scipy.signal import butter, sosfiltfilt
 
 from neurodsp.utils import remove_nans, restore_nans
-from neurodsp.filt.utils import compute_nyquist, compute_frequency_response
-from neurodsp.filt.checks import check_filter_definition, check_filter_properties
+from neurodsp.filt.utils import compute_nyquist, compute_frequency_response, sos_compute_frequency_response
+from neurodsp.filt.checks import check_filter_definition, check_filter_properties, sos_check_filter_properties
 from neurodsp.plts.filt import plot_frequency_response
 
 ###################################################################################################
@@ -42,14 +42,14 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     plot_properties : bool, optional, default: False
         If True, plot the properties of the filter, including frequency response and/or kernel.
     return_filter : bool, optional, default: False
-        If True, return the filter coefficients of the IIR filter.
+        If True, return the second order series coefficients of the IIR filter.
 
     Returns
     -------
     sig_filt : 1d array
         Filtered time series.
-    filter_coefs : tuple of (1d array, 1d array)
-        Filter coefficients of the IIR filter, as (b_vals, a_vals).
+    sos : 2d array of shape (n, 6)
+        Second order series coefficients of the IIR filter.
         Only returned if `return_filter` is True.
 
     Examples
@@ -64,42 +64,40 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     """
 
     # Design filter
-    b_vals, a_vals = design_iir_filter(fs, pass_type, f_range, butterworth_order)
+    sos = design_iir_filter(fs, pass_type, f_range, butterworth_order)
 
     # Check filter properties: compute transition bandwidth & run checks
-    check_filter_properties(b_vals, a_vals, fs, pass_type, f_range, verbose=print_transitions)
+    sos_check_filter_properties(sos, fs, pass_type, f_range, verbose=print_transitions)
 
     # Remove any NaN on the edges of 'sig'
     sig, sig_nans = remove_nans(sig)
 
     # Apply filter
-    sig_filt = apply_iir_filter(sig, b_vals, a_vals)
+    sig_filt = apply_iir_filter(sig, sos)
 
     # Add NaN back on the edges of 'sig', if there were any at the beginning
     sig_filt = restore_nans(sig_filt, sig_nans)
 
     # Plot frequency response, if desired
     if plot_properties:
-        f_db, db = compute_frequency_response(b_vals, a_vals, fs)
+        f_db, db = sos_compute_frequency_response(sos, fs)
         plot_frequency_response(f_db, db)
 
     if return_filter:
-        return sig_filt, (b_vals, a_vals)
+        return sig_filt, sos
     else:
         return sig_filt
 
 
-def apply_iir_filter(sig, b_vals, a_vals):
+def apply_iir_filter(sig, sos):
     """Apply an IIR filter to a signal.
 
     Parameters
     ----------
     sig : array
         Time series to be filtered.
-    b_vals : 1d array
-        B value filter coefficients for an IIR filter.
-    a_vals : 1d array
-        A value filter coefficients for an IIR filter.
+    sos : 2d array of shape (n, 6)
+        Second order series coefficients for an IIR filter.
 
     Returns
     -------
@@ -113,12 +111,12 @@ def apply_iir_filter(sig, b_vals, a_vals):
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
     ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
-    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
+    >>> sos = design_iir_filter(fs=500, pass_type='bandstop',
     ...                                    f_range=(55, 65), butterworth_order=7)
-    >>> filt_signal = apply_iir_filter(sig, b_vals, a_vals)
+    >>> filt_signal = apply_iir_filter(sig, sos)
     """
 
-    return filtfilt(b_vals, a_vals, sig)
+    return sosfiltfilt(sos, sig)
 
 
 def design_iir_filter(fs, pass_type, f_range, butterworth_order):
@@ -146,17 +144,15 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
 
     Returns
     -------
-    b_vals : 1d array
-        B value filter coefficients for an IIR filter.
-    a_vals : 1d array
-        A value filter coefficients for an IIR filter.
+    sos : 2d array of shape (n, 6)
+        Second order series coefficients for an IIR filter.
 
     Examples
     --------
     Compute coefficients for a bandstop IIR filter:
 
-    >>> b_vals, a_vals = design_iir_filter(fs=500, pass_type='bandstop',
-    ...                                    f_range=(55, 65), butterworth_order=7)
+    >>> sos = design_iir_filter(fs=500, pass_type='bandstop',
+    ...                         f_range=(55, 65), butterworth_order=7)
     """
 
     # Check filter definition
@@ -171,6 +167,6 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
         win = f_hi / f_nyq
 
     # Design filter
-    b_vals, a_vals = butter(butterworth_order, win, pass_type)
+    sos = butter(butterworth_order, win, pass_type, output='sos')
 
-    return b_vals, a_vals
+    return sos

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -159,10 +159,6 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
     ...                                    f_range=(55, 65), butterworth_order=7)
     """
 
-    # Warn about only recommending IIR for bandstop
-    if pass_type != 'bandstop':
-        warn('IIR filters are not recommended other than for notch filters.')
-
     # Check filter definition
     f_lo, f_hi = check_filter_definition(pass_type, f_range)
 

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -1,12 +1,10 @@
 """Filter signals with IIR filters."""
 
-from warnings import warn
-
 from scipy.signal import butter, sosfiltfilt
 
 from neurodsp.utils import remove_nans, restore_nans
-from neurodsp.filt.utils import compute_nyquist, compute_frequency_response, sos_compute_frequency_response
-from neurodsp.filt.checks import check_filter_definition, check_filter_properties, sos_check_filter_properties
+from neurodsp.filt.utils import compute_nyquist, compute_frequency_response
+from neurodsp.filt.checks import check_filter_definition, check_filter_properties
 from neurodsp.plts.filt import plot_frequency_response
 
 ###################################################################################################
@@ -48,8 +46,8 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     -------
     sig_filt : 1d array
         Filtered time series.
-    sos : 2d array of shape (n, 6)
-        Second order series coefficients of the IIR filter.
+    sos : 2d array
+        Second order series coefficients of the IIR filter. Has shape of (n_sections, 6).
         Only returned if `return_filter` is True.
 
     Examples
@@ -67,7 +65,7 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     sos = design_iir_filter(fs, pass_type, f_range, butterworth_order)
 
     # Check filter properties: compute transition bandwidth & run checks
-    sos_check_filter_properties(sos, fs, pass_type, f_range, verbose=print_transitions)
+    check_filter_properties(sos, None, fs, pass_type, f_range, verbose=print_transitions)
 
     # Remove any NaN on the edges of 'sig'
     sig, sig_nans = remove_nans(sig)
@@ -80,7 +78,7 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
 
     # Plot frequency response, if desired
     if plot_properties:
-        f_db, db = sos_compute_frequency_response(sos, fs)
+        f_db, db = compute_frequency_response(sos, None, fs)
         plot_frequency_response(f_db, db)
 
     if return_filter:
@@ -96,8 +94,8 @@ def apply_iir_filter(sig, sos):
     ----------
     sig : array
         Time series to be filtered.
-    sos : 2d array of shape (n, 6)
-        Second order series coefficients for an IIR filter.
+    sos : 2d array
+        Second order series coefficients for an IIR filter. Has shape of (n_sections, 6).
 
     Returns
     -------
@@ -144,8 +142,8 @@ def design_iir_filter(fs, pass_type, f_range, butterworth_order):
 
     Returns
     -------
-    sos : 2d array of shape (n, 6)
-        Second order series coefficients for an IIR filter.
+    sos : 2d array
+        Second order series coefficients for an IIR filter. Has shape of (n_sections, 6).
 
     Examples
     --------

--- a/neurodsp/tests/test_filt_checks.py
+++ b/neurodsp/tests/test_filt_checks.py
@@ -46,8 +46,18 @@ def test_check_filter_definition():
 def test_check_filter_properties():
 
     filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12))
-    check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
-    assert True
+    
+    passes = check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
+    assert passes is True
+
+    filter_coefs = design_fir_filter(FS, 'bandstop', (8, 12))
+    passes = check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
+    assert passes is False
+
+    filter_coefs = design_fir_filter(FS, 'bandpass', (20, 21))
+    passes = check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
+    assert passes is False
+
 
 def test_check_filter_length():
 

--- a/neurodsp/tests/test_filt_fir.py
+++ b/neurodsp/tests/test_filt_fir.py
@@ -1,5 +1,6 @@
 """Tests for FIR filters."""
 
+from pytest import raises
 import numpy as np
 
 from neurodsp.tests.settings import FS
@@ -56,3 +57,7 @@ def test_compute_filter_length():
     expected_filt_len = int(np.ceil(fs * n_cycles / f_lo)) + 1
     filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi, n_cycles=n_cycles, n_seconds=None)
     assert filt_len == expected_filt_len
+
+    with raises(ValueError):
+        filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi)
+

--- a/neurodsp/tests/test_filt_iir.py
+++ b/neurodsp/tests/test_filt_iir.py
@@ -22,7 +22,7 @@ def test_filter_signal_iir_2d(tsig2d):
 
 def test_apply_iir_filter(tsig):
 
-    out = apply_iir_filter(tsig, np.array([1, 1, 1, 1, 1]), np.array([1, 1, 1, 1, 1]))
+    out = apply_iir_filter(tsig, np.array([1, 1, 1, 1, 1, 1]))
     assert out.shape == tsig.shape
 
 def test_design_iir_filter():

--- a/neurodsp/tests/test_filt_iir.py
+++ b/neurodsp/tests/test_filt_iir.py
@@ -20,6 +20,9 @@ def test_filter_signal_iir_2d(tsig2d):
    assert out.shape == tsig2d.shape
    assert sum(~np.isnan(out[0, :])) > 0
 
+   out, sos = filter_signal_iir(tsig2d, FS, 'bandpass', (8, 12), 3, return_filter=True)
+   assert np.shape(sos)[1] == 6
+
 def test_apply_iir_filter(tsig):
 
     out = apply_iir_filter(tsig, np.array([1, 1, 1, 1, 1, 1]))

--- a/neurodsp/tests/test_filt_utils.py
+++ b/neurodsp/tests/test_filt_utils.py
@@ -1,5 +1,6 @@
 """Tests for filter utilities."""
 
+from pytest import raises
 from neurodsp.tests.settings import FS
 
 from neurodsp.filt.utils import *
@@ -18,6 +19,9 @@ def test_compute_frequency_response():
 
     filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12))
     f_db, db = compute_frequency_response(filter_coefs, 1, FS)
+
+    with raises(ValueError):
+        f_db, db = compute_frequency_response(filter_coefs, None, FS)
 
 def test_compute_pass_band():
 


### PR DESCRIPTION
This PR addresses issue #193 for the filt submodule. Specifically, the following modifications have been made:

1. Update function call in fir.py for firwin(). We now feed in the sampling rate directly, rather than feeding in the deprecated argument nyq, or the nyquist frequency.
2. Previously a warning was raised if you asked for a IIR butterworth filter that was anything but a bandpass. That warning has now been removed.
3. Most importantly, I made changes to how IIR filters are now computed. Instead of computing a and b coefficients of the transfer function, we now compute the second order series expansion. This addresses numerical instabilities for butterworth filters of higher orders. I did not want to change any of the checks or utils for FIR filters, so I created new functions for IIR filters by prepending "sos_" to the function handles. I updated doc strings in all of the functions which referenced a and b values for IIR filters. Finally, I updated the test test_apply_iir_filter to take as input a second order series expansion rather than two arrays of a and b coefficients. *TL;DR*: IIR filters and related functions now exclusively use second order series representations. FIR filters and related functions are left untouched. This addresses numerical instabilities.