### PR TITLE
[BUG] - Technical Audit: Time Frequency edits

### DIFF
--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -106,7 +106,7 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
         freqs = create_freqs(*freqs)
 
     mwt = compute_wavelet_transform(sig, fs, freqs, **kwargs)
-    spectrum = get_avg_func(avg_type)(mwt, axis=0)
+    spectrum = get_avg_func(avg_type)(mwt, axis=1)
 
     return freqs, spectrum
 

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -106,7 +106,7 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
         freqs = create_freqs(*freqs)
 
     mwt = compute_wavelet_transform(sig, fs, freqs, **kwargs)
-    spectrum = get_avg_func(avg_type)(mwt, axis=1)
+    spectrum = get_avg_func(avg_type)(abs(mwt)**2, axis=1)
 
     return freqs, spectrum
 

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -193,12 +193,10 @@ def freq_by_time(sig, fs, f_range=None, hilbert_increase_n=False,
     ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
     >>> instant_freq = freq_by_time(sig, fs=500, f_range=(8, 12))
     """
-
-    pha = phase_by_time(sig, fs, f_range, hilbert_increase_n,
-                        remove_edges, **filter_kwargs)
+    pha = np.unwrap(phase_by_time(sig, fs, f_range, hilbert_increase_n,
+                        remove_edges, **filter_kwargs))
 
     phadiff = np.diff(pha)
-    phadiff[phadiff < 0] = phadiff[phadiff < 0] + 2 * np.pi
 
     i_f = fs * phadiff / (2 * np.pi)
     i_f = np.insert(i_f, 0, np.nan)

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -26,7 +26,7 @@ def robust_hilbert(sig, increase_n=False):
     Returns
     -------
     sig_hilb : 1d array
-        The Hilbert transform of the input signal.
+        The analytic signal, of which the imaginary part is the Hilbert transform of the input signal.
 
     Examples
     --------

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -48,9 +48,9 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
         freqs = create_freqs(*freqs)
     n_cycles = check_n_cycles(n_cycles, len(freqs))
 
-    mwt = np.zeros([len(sig), len(freqs)], dtype=complex)
+    mwt = np.zeros([len(freqs), len(sig)], dtype=complex)
     for ind, (freq, n_cycle) in enumerate(zip(freqs, n_cycles)):
-        mwt[:, ind] = convolve_wavelet(sig, fs, freq, n_cycle, scaling)
+        mwt[ind, :] = convolve_wavelet(sig, fs, freq, n_cycle, scaling)
 
     return mwt
 

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -24,8 +24,9 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5, norm='sss
         If array, frequency values to estimate with morlet wavelets.
         If list, define the frequency range, as [freq_start, freq_stop, freq_step].
         The `freq_step` is optional, and defaults to 1. Range is inclusive of `freq_stop` value.
-    n_cycles : float
+    n_cycles : float, or 1d array.
         Length of the filter, as the number of cycles for each frequency.
+        If 1d array, this defines n_cycles for each frequency.
     scaling : float
         Scaling factor.
 

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -29,6 +29,12 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5, norm='sss
     scaling : float
         Scaling factor.
 
+    norm : {'sss', 'amp'}, optional
+        Normalization method:
+
+        * 'sss' - divide by the square root of the sum of squares
+        * 'amp' - divide by the sum of amplitudes
+
     Returns
     -------
     mwt : 2d array

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -24,12 +24,11 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5, norm='sss
         If array, frequency values to estimate with morlet wavelets.
         If list, define the frequency range, as [freq_start, freq_stop, freq_step].
         The `freq_step` is optional, and defaults to 1. Range is inclusive of `freq_stop` value.
-    n_cycles : float, or 1d array.
+    n_cycles : float or 1d array
         Length of the filter, as the number of cycles for each frequency.
         If 1d array, this defines n_cycles for each frequency.
     scaling : float
         Scaling factor.
-
     norm : {'sss', 'amp'}, optional
         Normalization method:
 

--- a/neurodsp/timefrequency/wavelets.py
+++ b/neurodsp/timefrequency/wavelets.py
@@ -11,7 +11,7 @@ from neurodsp.utils.decorators import multidim
 ###################################################################################################
 
 @multidim()
-def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
+def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5, norm='sss'):
     """Compute the time-frequency representation of a signal using morlet wavelets.
 
     Parameters
@@ -50,7 +50,7 @@ def compute_wavelet_transform(sig, fs, freqs, n_cycles=7, scaling=0.5):
 
     mwt = np.zeros([len(freqs), len(sig)], dtype=complex)
     for ind, (freq, n_cycle) in enumerate(zip(freqs, n_cycles)):
-        mwt[ind, :] = convolve_wavelet(sig, fs, freq, n_cycle, scaling)
+        mwt[ind, :] = convolve_wavelet(sig, fs, freq, n_cycle, scaling, norm=norm)
 
     return mwt
 


### PR DESCRIPTION
This PR addresses the concerns raised in issue #193 for the time frequency analysis submodule, as well as the semantic issue  raised in issue #196. Specifically,

1. `compute_wavelet_transform` now has `norm` as a kwarg to specify what normalization to use. It defaults to `sss`, or the L2 norm. Moreover, the output has been transposed so that frequency is plotted on the y-axis, and time on the x-axis. This matches convention for wavelet transforms in other packages.

2. Update the test for `compute_wavelet_transform` to average across the appropriate axis.

3. We now wrap the instantaneous phase vector using `np.unwrap` inside the call of `freq_by_time`. 

4. Update the docstring for `robust_hilbert` to reflect that the return value is the analytic signal, not the hilbert transform.