### PR TITLE
[ENH] - Spectral: Trim Spectrogram

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -145,6 +145,7 @@ Spectral Utilities
     :toctree: generated/
 
     trim_spectrum
+    trim_spectrogram
     rotate_powerlaw
 
 Burst Detection

--- a/neurodsp/spectral/__init__.py
+++ b/neurodsp/spectral/__init__.py
@@ -3,4 +3,4 @@
 from .power import (compute_spectrum, compute_spectrum_welch,
                     compute_spectrum_wavelet, compute_spectrum_medfilt)
 from .variance import compute_scv, compute_scv_rs, compute_spectral_hist
-from .utils import trim_spectrum, rotate_powerlaw
+from .utils import trim_spectrum, trim_spectrogram, rotate_powerlaw

--- a/neurodsp/spectral/utils.py
+++ b/neurodsp/spectral/utils.py
@@ -13,7 +13,8 @@ def trim_spectrum(freqs, power_spectra, f_range):
     freqs : 1d array
         Frequency values for the power spectrum.
     power_spectra : 1d or 2d array
-        Power spectral density values.
+        Power spectral density values. If 2d, formatted as
+        [n_spectra, n_freqs].
     f_range: list of [float, float]
         Frequency range to restrict to, as [f_low, f_high].
 
@@ -50,6 +51,77 @@ def trim_spectrum(freqs, power_spectra, f_range):
         else power_spectra[:, f_mask]
 
     return freqs_ext, power_spectra_ext
+
+def trim_spectrogram(freqs, times, spg, f_range=None, t_range=None):
+    """Extract a frequency or time range of interest from a spectrogram.
+
+    Parameters
+    ----------
+    freqs : 1d array
+        Frequency values for the spectrogram.
+    times: 1d array
+        Time values for the spectrogram.
+    spg : 2d array
+        Spectrogram, or time frequency representation of a signal.
+        Formatted as [n_freqs, n_time_windows].
+    f_range: list of [float, float]
+        Frequency range to restrict to, as [f_low, f_high].
+    t_range: list of [float, float]
+        Time range to restrict to, as [t_low, t_high].
+
+    Returns
+    -------
+    freqs_ext : 1d array
+        Extracted frequency values for the power spectrum.
+    t_ext: 1d array
+        Extracted segment time values
+    spg_ext : 2d array
+        Extracted spectrogram values.
+
+    Notes
+    -----
+    This function extracts frequency ranges >= f_low and <= f_high,
+    and time ranges >= t_low and <= t_high. It does not round to below 
+    or above f_low and f_high, or t_low and t_high, respectively.
+
+    Examples
+    --------
+    Trim the spectrogram of a simulated time series:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> from neurodsp.timefrequency import compute_wavelet_transform
+    >>> from neurodsp.utils.data import create_times, create_freqs
+    >>> fs = 500
+    >>> n_seconds = 10
+    >>> times = create_times(n_seconds, fs)
+    >>> sig = sim_combined(n_seconds, fs,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation' : {'freq': 10}})
+    >>> freqs = create_freqs(1, 15)
+    >>> mwt = compute_wavelet_transform(sig, fs, freqs)
+    >>> spg = abs(mwt)**2
+    >>> freqs_ext, t_ext, spg_ext = trim_spectrogram(freqs, times, spg, f_range=[8, 12], t_range=[0, 5])
+    """
+
+    # Initialize spg_ext to spg to avoid not defining it in the case where neither
+    # f_range nor t_range is defined.
+    spg_ext = spg
+
+    # Check which axes of spectrogram to trim.
+    if f_range is not None:
+        f_mask = np.logical_and(freqs >= f_range[0], freqs <= f_range[1])
+        freqs_ext = freqs[f_mask]
+        spg_ext = spg_ext[f_mask, :]
+    else:
+        freqs_ext = freqs
+
+    if t_range is not None:
+        t_mask = np.logical_and(times >= t_range[0], times <= t_range[1])
+        t_ext = times[t_mask]
+        spg_ext = spg_ext[:, t_mask]
+    else:
+        times_ext = times
+    
+    return freqs_ext, t_ext, spg_ext
 
 
 def rotate_powerlaw(freqs, spectrum, delta_exponent, f_rotation=1):

--- a/neurodsp/tests/test_spectral_utils.py
+++ b/neurodsp/tests/test_spectral_utils.py
@@ -17,6 +17,20 @@ def test_trim_spectrum():
     assert_equal(freqs_new, np.array([6, 7, 8]))
     assert_equal(pows_new, np.array([2, 3, 4]))
 
+def test_trim_spectrogram():
+
+    freqs = np.array([5, 6, 7, 8])
+    times = np.array([0, 1, 2,])
+    pows = np.array([[1, 2, 3],
+                     [4, 5, 6],
+                     [7, 8, 9],
+                     [10, 11, 12]])
+
+    freqs_new, t_new, pows_new = trim_spectrogram(freqs, times, pows, f_range=[6, 8], t_range=[0,1])
+    assert_equal(freqs_new, np.array([6, 7, 8]))
+    assert_equal(t_new, np.array([0, 1]))
+    assert_equal(pows_new, np.array([[4, 5], [7, 8], [10, 11]]))
+
 def test_rotate_powerlaw():
 
     freqs = np.array([5, 6, 7, 8, 9])


### PR DESCRIPTION
This PR adds `trim_spectrogram` which allows a user to trim particular frequency and time values from a spectrogram. 