### PR TITLE
[ENH] Conda Support

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+# Conda-forge instructions:
+#   - Fork the feedstock repo (https://github.com/conda-forge/neurodsp-feedstock).
+#   - Update the meta.yaml file.
+#   - Make a pull request. Once merged, the package will be rebuilt on the conda-forge channel.
+
+# Anaconda is required to upload to Anaconda Cloud.
+if [[ $(which anaconda) == '' ]]; then
+    echo "Anaconda is not installed or not in \$PATH. Exiting."
+    exit 1
+fi
+
+# Install conda-build if not found.
+if [[ $(conda list | grep conda-build) == '' ]]; then
+    echo "Installing conda-build."
+    conda install conda-build
+fi
+
+# Install anaconda-client if not found.
+if [[ $(conda list | grep anaconda-client) == '' ]]; then
+    echo "Installing anaconda-client."
+    conda install anaconda-client
+fi
+
+# Build
+mkdir -p build
+echo "Building..."
+conda build neurodsp --output-folder=build >> build.log 2>&1
+build=$(conda build neurodsp --output-folder=build --output)
+
+# Upload. Note: this will prompt a username/password
+echo "Uploading to cloud..."
+anaconda upload --user neurodsp-tools $build
+
+echo -e "To install neurodsp with conda, run:\n\tconda install -c neurodsp-tools neurodsp"

--- a/conda/neurodsp/meta.yaml
+++ b/conda/neurodsp/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "neurodsp" %}
+{% set version = "2.0.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 046f14564a0d7f7982bdbafdc7c0c374f96c9625ec8199ee665663bf0cd47642
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - numpy
+    - scipy
+    - matplotlib-base
+
+test:
+  imports:
+    - neurodsp
+    - neurodsp.burst
+    - neurodsp.filt
+    - neurodsp.plts
+    - neurodsp.rhythm
+    - neurodsp.sim
+    - neurodsp.spectral
+    - neurodsp.tests
+    - neurodsp.timefrequency
+    - neurodsp.utils
+  requires:
+    - pytest
+
+about:
+  home: "https://github.com/neurodsp-tools/neurodsp"
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: "Digital signal processing for neural time series."
+  doc_url: "https://neurodsp-tools.github.io/neurodsp/"
+  dev_url: "https://github.com/neurodsp-tools/neurodsp"
+
+extra:
+  recipe-maintainers:
+    - ryanhammonds


### PR DESCRIPTION
I'm not a conda user, however, I went ahead and created a script to push pypi builds to conda. Neurodsp may now be install using `conda install -c neurodsp-tools neurodsp`. The shell script should only be execute when a new pypi build is available, although it shouldn't hurt if ran twice on accident, as it defaults to the latest pypi build. The script will prompt for an Anaconda username/password. Accounts may be created [here](https://anaconda.org/). If anyone wants to manage the Anaconda orgs, fell free to send me your Anaconda username, and I can added owners to the Anaconda organization(s).

I have created neurodsp-tools, fooof-tools, bycycle-tools, and lisc-tools organizations on Anaconda. The shell script just has to be adjusted a bit and all these repos will become conda installable.

Edit: Ah, I just noticed the conda issue mentions conda-forge, rather than anaconda. I think the installation command will be the same, it just changes were the conda package is hosted.