### PR TITLE
[BUG] - Fix the sims normalizations

### DIFF
--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -2,8 +2,9 @@
 
 import numpy as np
 
-from neurodsp.utils.decorators import normalize
 from neurodsp.sim.transients import sim_cycle
+from neurodsp.utils.norm import normalize_sig
+from neurodsp.utils.decorators import normalize
 
 ###################################################################################################
 ###################################################################################################
@@ -53,7 +54,6 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', **cycle_params):
     return sig
 
 
-@normalize
 def sim_bursty_oscillation(n_seconds, fs, freq, enter_burst=.2, leave_burst=.2,
                            cycle='sine', **cycle_params):
     """Simulate a bursty oscillation.
@@ -108,8 +108,15 @@ def sim_bursty_oscillation(n_seconds, fs, freq, enter_burst=.2, leave_burst=.2,
     n_samples = int(n_seconds * fs)
     n_seconds_cycle = (1/freq * fs)/fs
 
-    # Make a single cycle of an oscillation
+    # Grab normalization parameters, if any were provided
+    mean = cycle_params.pop('mean', 0.)
+    variance = cycle_params.pop('variance', 1.)
+
+    # Make a single cycle of an oscillation, and normalize this cycle
     osc_cycle = sim_cycle(n_seconds_cycle, fs, cycle, **cycle_params)
+    osc_cycle = normalize_sig(osc_cycle, mean, variance)
+
+    # Calculate how many cycles are needed to tile the full signal
     n_samples_cycle = len(osc_cycle)
     n_cycles = int(np.floor(n_samples / n_samples_cycle))
 

--- a/neurodsp/tests/utils/test_norm.py
+++ b/neurodsp/tests/utils/test_norm.py
@@ -7,6 +7,19 @@ from neurodsp.utils.norm import *
 ###################################################################################################
 ###################################################################################################
 
+def test_normalize_sig():
+
+    sig1 = np.array([1, 2, 3, 4, 5, 6])
+    sig2 = np.array([0, 1, 0, -1, 0, 1, 0, -1])
+
+    new_mean = 2
+    new_variance = 2
+
+    for sig in [sig1, sig2]:
+        out = normalize_sig(sig, new_mean, new_variance)
+        assert np.isclose(out.mean(), new_mean)
+        assert np.isclose(out.var(), new_variance)
+
 def test_demean():
 
     d1 = np.array([1, 2, 3])
@@ -17,12 +30,9 @@ def test_demean():
     assert np.isclose(out1.mean(), 0.)
 
     # Check demeaning and adding specific mean
-    out2 = demean(d1, mean=1.)
-    assert np.isclose(out2.mean(), 1.)
-
-    # Check dealing with zero entries
-    out3 = demean(d2)
-    assert np.isclose(out3[np.nonzero(out3)].mean(), 0)
+    new_mean = 1.
+    out2 = demean(d1, mean=new_mean)
+    assert np.isclose(out2.mean(), new_mean)
 
 def test_normalize_variance():
 

--- a/neurodsp/tests/utils/test_norm.py
+++ b/neurodsp/tests/utils/test_norm.py
@@ -24,10 +24,6 @@ def test_demean():
     out3 = demean(d2)
     assert np.isclose(out3[np.nonzero(out3)].mean(), 0)
 
-    # Check turning of non-zero selection
-    out3 = demean(d2, mean=1, select_nonzero=False)
-    assert np.isclose(out3.mean(), 1)
-
 def test_normalize_variance():
 
     d1 = np.array([1, 2, 3])

--- a/neurodsp/utils/decorators.py
+++ b/neurodsp/utils/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import numpy as np
 
-from neurodsp.utils.norm import demean, normalize_variance
+from neurodsp.utils.norm import normalize_sig
 
 ###################################################################################################
 ###################################################################################################
@@ -23,11 +23,8 @@ def normalize(func, **kwargs):
         out = func(*args, **kwargs)
         sig = out[0] if isinstance(out, tuple) else out
 
-        # Apply variance & mean transformations
-        if variance is not None:
-            sig = normalize_variance(sig, variance=variance)
-        if mean is not None:
-            sig = demean(sig, mean=mean)
+        # Normalize signal, applying mean and variance transformations
+        sig = normalize_sig(sig, variance, mean)
 
         # Return sig & other outputs, if there were any, or just sig otherwise
         return (sig, out[1:]) if isinstance(out, tuple) else sig

--- a/neurodsp/utils/decorators.py
+++ b/neurodsp/utils/decorators.py
@@ -16,15 +16,15 @@ def normalize(func, **kwargs):
     def decorated(*args, **kwargs):
 
         # Grab variance & mean as possible kwargs, with default values if not
-        variance = kwargs.pop('variance', 1.)
         mean = kwargs.pop('mean', 0.)
+        variance = kwargs.pop('variance', 1.)
 
         # Call sim function, and unpack to get sig variable, if there are multiple returns
         out = func(*args, **kwargs)
         sig = out[0] if isinstance(out, tuple) else out
 
         # Normalize signal, applying mean and variance transformations
-        sig = normalize_sig(sig, variance, mean)
+        sig = normalize_sig(sig, mean, variance)
 
         # Return sig & other outputs, if there were any, or just sig otherwise
         return (sig, out[1:]) if isinstance(out, tuple) else sig

--- a/neurodsp/utils/norm.py
+++ b/neurodsp/utils/norm.py
@@ -5,7 +5,7 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-def demean(array, mean=0., select_nonzero=True):
+def demean(array, mean=0.):
     """Demean an array, updating to specified mean.
 
     Parameters
@@ -14,8 +14,6 @@ def demean(array, mean=0., select_nonzero=True):
         Data to demean.
     mean : float, optional, default: 0
         New mean for data to have.
-    select_nonzero : bool, optional, default: True
-        Whether to calculate the mean of the array across only non-zero data points.
 
     Returns
     -------
@@ -23,19 +21,10 @@ def demean(array, mean=0., select_nonzero=True):
         Demeaned data.
     """
 
-    if select_nonzero:
-        nonzero = np.nonzero(array)
-        nonzero_mean = np.mean(array[nonzero])
-        out = array.copy()
-        out[nonzero] = array[nonzero] - nonzero_mean + mean
-
-    else:
-        out = array - array.mean() + mean
-
-    return out
+    return array - array.mean() + mean
 
 
-def normalize_variance(array, variance=1., select_nonzero=True):
+def normalize_variance(array, variance=1.):
     """Normalize the variance of an array, updating to specified variance.
 
     Parameters
@@ -44,8 +33,6 @@ def normalize_variance(array, variance=1., select_nonzero=True):
         Data to normalize variance to.
     variance : float, optional, default: 1.0
         Variance to normalize to.
-    select_nonzero : bool, optional, default: True
-        Whether to calculate the variance of the array across only non-zero data points.
 
     Returns
     -------
@@ -57,19 +44,11 @@ def normalize_variance(array, variance=1., select_nonzero=True):
     If the input array is all zeros, this function simply returns the input.
     """
 
-    # If array is all zero, set to return the same array
-    #   Can't update variance if it's zero
+    # If array is all zero, set to return the same array (can't update variance of 0)
     if not array.any():
         out = array
 
     else:
-
-        if select_nonzero:
-            nonzero = np.nonzero(array)
-            array_std = np.std(array[nonzero])
-            out = array.copy()
-            out[nonzero] = array[nonzero] / array_std * np.sqrt(variance)
-        else:
-            out = array / array.std() * np.sqrt(variance)
+        out = array / array.std() * np.sqrt(variance)
 
     return out

--- a/neurodsp/utils/norm.py
+++ b/neurodsp/utils/norm.py
@@ -5,7 +5,7 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-def normalize_sig(sig, variance=None, mean=None):
+def normalize_sig(sig, mean=None, variance=None):
     """Normalize the mean and variance of a signal.
 
     Parameters

--- a/neurodsp/utils/norm.py
+++ b/neurodsp/utils/norm.py
@@ -5,6 +5,33 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
+def normalize_sig(sig, variance=None, mean=None):
+    """Normalize the mean and variance of a signal.
+
+    Parameters
+    ----------
+    sig : 1d array
+        Signal to normalize.
+    variance : float, optional
+        Variance to normalize to.
+    mean : float, optional
+        New mean for data to have.
+
+    Returns
+    -------
+    sig : 1d array
+        Input signal, with normalizations applied.
+    """
+
+    # Apply variance & mean transformations
+    if variance is not None:
+        sig = normalize_variance(sig, variance=variance)
+    if mean is not None:
+        sig = demean(sig, mean=mean)
+
+    return sig
+
+
 def demean(array, mean=0.):
     """Demean an array, updating to specified mean.
 


### PR DESCRIPTION
This PR drops the option in the normalization to only apply transforms to non-zero. This approach, designed to be able to normalize burst regions (ignoring surrounding zeros) turned out to be a bad idea, because there can be other zeros. This created some 'discontinuities' (issue noted in #174). In order to be able to normalize burst signals, without normalizing to non-burst regions, this PR also updates how normalizations get applied in `sim_burst_normalization`, applying them to the simulated signal before tiling. 

Note that this PR replaces #189, which was a wrong-headed fix, that tried to do resampling. 

Review Notes:
@ryanhammonds : if you can review this one, keep in mind it supercedes & adopts from #189, so you can review in light of what you did for that PR. 
@elybrand : since you've played with the sims and normalizations a little, I just wanted to tag you in to sanity check, if you want / can, that this makes sense to you (basically - see if you spot anything mathematically suspect, otherwise don't worry about code-level reviews). 
@rdgao : if you're interested, this is basically the replacement for #189 

Note: the commit log is slightly funky, because I rebased, and I think I didn't do it quite right... but the file diffs seem right. 