### PR TITLE
[ENH] - Add autocorrelation measure

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -195,6 +195,7 @@ Fluctuation Analyses
 .. autosummary::
     :toctree: generated/
 
+    compute_autocorr
     compute_fluctuations
     compute_irasa
     fit_irasa

--- a/neurodsp/aperiodic/__init__.py
+++ b/neurodsp/aperiodic/__init__.py
@@ -1,4 +1,5 @@
 """"Functions for calculating aperiodic properties of signals."""
 
 from .dfa import compute_fluctuations
+from .autocorr import compute_autocorr
 from .irasa import compute_irasa, fit_irasa

--- a/neurodsp/aperiodic/autocorr.py
+++ b/neurodsp/aperiodic/autocorr.py
@@ -12,10 +12,10 @@ def compute_autocorr(sig, max_lag=1000, lag_step=1):
     ----------
     sig : array 1D
         Time series to compute autocorrelation over.
-    max_lag : int (default=1000)
+    max_lag : int, optional, default: 1000
         Maximum delay to compute autocorrelations for, in samples.
-    lag_step : int (default=1)
-        Step size (lag advance) for computing correlations.
+    lag_step : int, optional, default: 1
+        Step size (lag advance) for computing autocorrelations.
 
     Returns
     -------

--- a/neurodsp/aperiodic/autocorr.py
+++ b/neurodsp/aperiodic/autocorr.py
@@ -5,7 +5,7 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-def compute_autocorr(sig, max_lag=1000, lag_step=1):
+def compute_autocorr(sig, max_lag=1000, lag_step=1, demean=True):
     """Compute the signal autocorrelation (lagged correlation).
 
     Parameters
@@ -16,6 +16,8 @@ def compute_autocorr(sig, max_lag=1000, lag_step=1):
         Maximum delay to compute autocorrelations for, in samples.
     lag_step : int, optional, default: 1
         Step size (lag advance) for computing autocorrelations.
+    demean : bool, optional, default: True
+        Whether to demean the signal before computing autcorralations.
 
     Returns
     -------
@@ -25,15 +27,13 @@ def compute_autocorr(sig, max_lag=1000, lag_step=1):
         Autocorrelation values, for across time lags.
     """
 
+    if demean:
+        sig = sig - sig.mean()
+
+    autocorrs = np.correlate(sig, sig, "full")[len(sig)-1:]
+    autocorrs = autocorrs[:max_lag] / autocorrs[0]
+    autocorrs = autocorrs[::lag_step]
+
     timepoints = np.arange(0, max_lag, lag_step)
-    autocorrs = np.zeros(len(timepoints))
-
-    autocorrs[0] = np.sum((sig - np.mean(sig))**2)
-
-    for ind, lag in enumerate(timepoints[1:]):
-        autocorrs[ind + 1] = \
-            np.sum((sig[:-lag] - np.mean(sig[:-lag])) * (sig[lag:] - np.mean(sig[lag:])))
-
-    autocorrs = autocorrs / autocorrs[0]
 
     return timepoints, autocorrs

--- a/neurodsp/aperiodic/autocorr.py
+++ b/neurodsp/aperiodic/autocorr.py
@@ -1,0 +1,39 @@
+"""Autocorrelation analyses of time series."""
+
+import numpy as np
+
+###################################################################################################
+###################################################################################################
+
+def compute_autocorr(sig, max_lag=1000, lag_step=1):
+    """Compute the signal autocorrelation (lagged correlation).
+
+    Parameters
+    ----------
+    sig : array 1D
+        Time series to compute autocorrelation over.
+    max_lag : int (default=1000)
+        Maximum delay to compute autocorrelations for, in samples.
+    lag_step : int (default=1)
+        Step size (lag advance) for computing correlations.
+
+    Returns
+    -------
+    timepoints : 1d array
+        Time points, in samples, at which autocorrelations are computed.
+    autocorrs : 1d array
+        Autocorrelation values, for across time lags.
+    """
+
+    timepoints = np.arange(0, max_lag, lag_step)
+    autocorrs = np.zeros(len(timepoints))
+
+    autocorrs[0] = np.sum((sig - np.mean(sig))**2)
+
+    for ind, lag in enumerate(timepoints[1:]):
+        autocorrs[ind + 1] = \
+            np.sum((sig[:-lag] - np.mean(sig[:-lag])) * (sig[lag:] - np.mean(sig[lag:])))
+
+    autocorrs = autocorrs / autocorrs[0]
+
+    return timepoints, autocorrs

--- a/neurodsp/aperiodic/autocorr.py
+++ b/neurodsp/aperiodic/autocorr.py
@@ -17,7 +17,7 @@ def compute_autocorr(sig, max_lag=1000, lag_step=1, demean=True):
     lag_step : int, optional, default: 1
         Step size (lag advance) for computing autocorrelations.
     demean : bool, optional, default: True
-        Whether to demean the signal before computing autcorralations.
+        Whether to demean the signal before computing autocorrelations.
 
     Returns
     -------

--- a/neurodsp/tests/aperiodic/test_autocorr.py
+++ b/neurodsp/tests/aperiodic/test_autocorr.py
@@ -1,0 +1,11 @@
+"""Tests for autocorrelation measures."""
+
+from neurodsp.aperiodic.autocorr import *
+
+###################################################################################################
+###################################################################################################
+
+def test_compute_autocorr(tsig):
+
+    timepoints, autocorrs = compute_autocorr(tsig)
+    assert len(timepoints) == len(autocorrs)


### PR DESCRIPTION
Add a function to compute autocorrelation of time series. 

Note: this implementation was shamelessly taken and adapted from @rdgao's implementation. I'm suggesting we add this functionality, for a stable implementation, including for use in the AperiodicMethods project. Does that sound good to use @rdgao?

For reviewing, the usual: @elybrand please check if the math works / makes sense, and @ryanhammonds please sanity check the code, tests, etc. 