### PR TITLE
[BUG] - Fix bug in fitting IRASA

### DIFF
--- a/neurodsp/aperiodic/irasa.py
+++ b/neurodsp/aperiodic/irasa.py
@@ -116,7 +116,7 @@ def fit_irasa(freqs, psd_aperiodic):
     This fits a linear function of the form `y = ax + b` to the log-log aperiodic power spectrum.
     """
 
-    popt, _ = curve_fit(fit_func, np.log(freqs), np.log(psd_aperiodic))
+    popt, _ = curve_fit(fit_func, np.log10(freqs), np.log10(psd_aperiodic))
     intercept, slope = popt
 
     return intercept, slope


### PR DESCRIPTION
Fix to fit spectrum in log10 spacing. Currently, uses natural log (np.log instead of np.log10). This doesn't matter for the slope estimation - but it makes the units of the fit offset all weird.