### PR TITLE
[ENH] - Simulation of Central Frequency in the Time Domain

### DIFF
--- a/neurodsp/sim/__init__.py
+++ b/neurodsp/sim/__init__.py
@@ -6,4 +6,4 @@ from .periodic import sim_oscillation, sim_bursty_oscillation
 from .aperiodic import sim_powerlaw, sim_random_walk, sim_synaptic_current, sim_poisson_pop
 from .cycles import sim_cycle
 from .transients import sim_synaptic_kernel
-from .combined import sim_combined
+from .combined import sim_combined, sim_central_freq

--- a/neurodsp/sim/__init__.py
+++ b/neurodsp/sim/__init__.py
@@ -6,4 +6,4 @@ from .periodic import sim_oscillation, sim_bursty_oscillation
 from .aperiodic import sim_powerlaw, sim_random_walk, sim_synaptic_current, sim_poisson_pop
 from .cycles import sim_cycle
 from .transients import sim_synaptic_kernel
-from .combined import sim_combined, sim_central_freq
+from .combined import sim_combined, sim_peak_oscillation

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -87,53 +87,49 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
 
 
 @normalize
-def sim_central_freq(n_seconds, fs, central_freq, bw, ht, ap_func='sim_powerlaw',
-                     ap_kwargs={'exponent': -2}):
-    """
-    Returns a time series whose full power spectrum consists of an aperiodic component
-    and a gaussian peak at central_freq with standard deviation bw and relative height ht.
-
+def sim_peak_oscillation(sig_ap, fs, freq, bw, height):
+    """Returns a time series whose full power spectrum consists of an aperiodic component
+    and a gaussian peak at ``freq`` with standard deviation ``bw`` and relative ``height``.
 
     Parameters
     -----------
-    n_seconds: float
-        Number of seconds elapsed in the time series.
+    sig_ap : 1d array
+        The timeseries of the aperiodic component.
     fs: float
-        Sampling rate.
-    central_freq: float
+        Sampling rate of ``sig_ap``.
+    freq: float
         Central frequency for the gaussian peak in Hz.
     bw: float
         Bandwidth, or standard deviation, of gaussian peak in Hz.
-    ht: float
-        Relative height in log_10(Hz) over the aperiodic component of the gaussian peak at
-        central_freq.
-    ap_func : str, optional, default: 'sim_powerlaw'
-        An aperiodic simulation function from ``neurodsp.sim.aperiodic``.
-    ap_kwargs : dict, optional, default: {'exponent': -2}
-        Keyword arguments to use with ``ap_func``.
+    height: float
+        Relative height in log_10(Hz) over the aperiodic component of the gaussian peak at the
+        central ``freq``.
 
     Returns
     -------
     sig: 1d array
         Time series with desired power spectrum.
 
+    Notes
+    -----
+    The periodic component of the signal will be sinusoidal.
+
     Examples
     --------
     Simulate an aperiodic component with exponent -2 superimposed over
     an oscillatory component with central frequency 20.
 
-    >>> sig = sim_central_freq(n_seconds=50, fs=500, central_freq=20, bw=5, ht=7,
-    ...                        ap_func='sim_powerlaw', ap_params={'exponent': -2})
+    >>> from neurodsp.sim import sim_powerlaw
+    >>> fs = 500
+    >>> sig_ap = sim_powerlaw(n_seconds=10, fs=fs)
+    >>> sig = sim_peak_oscillation(sig_ap, fs=fs, freq=20, bw=5, height=7)
     """
 
-    times = create_times(n_seconds, fs)
+    sig_len = len(sig_ap)
+    times = create_times(sig_len/fs, fs)
 
     # Construct the aperiodic component and compute its Fourier transform. Only use the
     # first half of the frequencies from the Fourier transform since the signal is real.
-    sig_components = {ap_func: ap_kwargs}
-    sig_ap = sim_combined(n_seconds, fs, sig_components)
-    sig_len = sig_ap.shape[0]
-
     sig_ap_hat = np.fft.fft(sig_ap)[0:(sig_len//2+1)]
 
     # Create the range of frequencies that appear in the power spectrum since these
@@ -141,31 +137,27 @@ def sim_central_freq(n_seconds, fs, central_freq, bw, ht, ap_func='sim_powerlaw'
     freqs = np.linspace(0, fs/2, num=sig_len//2 + 1, endpoint=True)
 
     # Construct the array of relative heights above the aperiodic power spectrum
-    rel_heights = np.array([ ht * np.exp(-(f - central_freq)**2/(2*bw**2)) for f in freqs])
+    rel_heights = np.array([height * np.exp(-(lin_freq - freq)**2/(2*bw**2)) for lin_freq in freqs])
 
     # Build an array of the sum of squares of the cosines as they appear in the calculation of the
     # amplitudes
-    cosine_norms = np.array([
-                          norm(
-                            np.cos(2*np.pi*f*times), 2
-                          )**2 for f in freqs
-                        ])
+    cosine_norms = np.array(
+        [norm(np.cos(2*np.pi*lin_freq*times), 2)**2 for lin_freq in freqs]
+    )
 
     # Build an array of the amplitude coefficients
-    cosine_coeffs = np.array([
-                    (-np.real(sig_ap_hat[ell]) + np.sqrt(np.real(sig_ap_hat[ell])**2 + \
-                        (10**rel_heights[ell] - 1)*np.abs(sig_ap_hat[ell])**2))/cosine_norms[ell]
-                    for ell in range(cosine_norms.shape[0])]
-                )
+    cosine_coeffs = np.array(
+        [(-np.real(sig_ap_hat[ell]) + np.sqrt(np.real(sig_ap_hat[ell])**2 + \
+         (10**rel_heights[ell] - 1)*np.abs(sig_ap_hat[ell])**2))/cosine_norms[ell]
+         for ell in range(cosine_norms.shape[0])]
+    )
 
     # Add cosines with the respective coefficients and with a random phase shift for each one
     sig_periodic = np.sum(
-                    np.array(
-                        [cosine_coeffs[ell]*np.cos(2*np.pi*freqs[ell]*times + \
-                            2*np.pi*np.random.rand()) for ell in range(cosine_norms.shape[0])]
-                    ),
-                    axis=0
-                )
+        np.array([cosine_coeffs[ell]*np.cos(2*np.pi*freqs[ell]*times + 2*np.pi*np.random.rand())
+                  for ell in range(cosine_norms.shape[0])]),
+        axis=0
+    )
 
     sig = sig_ap + sig_periodic
 

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -3,9 +3,11 @@
 from itertools import repeat
 
 import numpy as np
+from scipy.linalg import norm
 
 from neurodsp.sim.info import get_sim_func
 from neurodsp.utils.decorators import normalize
+from neurodsp.utils.data import create_times
 
 ###################################################################################################
 ###################################################################################################
@@ -80,5 +82,83 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
 
     # Combine total signal across all simulated components
     sig = np.sum(sig_components, axis=0)
+
+    return sig
+
+@normalize
+def sim_central_freq(n_seconds, fs, chi, central_freq, bw, ht):
+    """
+    Returns a time series whose full power spectrum consists of a power law with exponent chi
+    and a gaussian peak at central_freq with standard deviation bw and relative height ht.
+    
+
+    Parameters
+    -----------
+    n_seconds: float
+        Number of seconds elapsed in the time series.
+    fs: float
+        Sampling rate.
+    chi: float
+        Power law exponent.
+    central_freq: float
+        Central frequency for the gaussian peak in Hz.
+    bw: float
+        Bandwidth, or standard deviation, of gaussian peak in Hz.
+    ht: float
+        Relative height in log_10(Hz) over the aperiodic component of the gaussian peak at central_freq.
+
+    Returns
+    -------
+    sig: 1d array
+        Time series with desired power spectrum.
+
+    Examples
+    --------
+    Simulate aperiodic noise with exponent -2 superimposed over an oscillatory component with
+    central frequency 20.
+
+    >>> sig = sim_gauss_peak(n_seconds=50, fs=500, chi=-2, central_freq=20, bw=5, ht=7)
+    """
+
+    times = create_times(n_seconds, fs)
+
+    # Construct the aperiodic component and compute its Fourier transform. Only use the
+    # first half of the frequencies from the Fourier transform since the signal is real.
+    sig_components = {'sim_powerlaw': {'exponent': chi}}
+    sig_ap = sim_combined(n_seconds, fs, sig_components)
+    sig_len = sig_ap.shape[0]
+
+    sig_ap_hat = np.fft.fft(sig_ap)[0:(sig_len//2+1)]
+
+    # Create the range of frequencies that appear in the power spectrum since these
+    # will be the frequencies in the cosines we sum below
+    freqs = np.linspace(0, fs/2, num=sig_len//2 + 1, endpoint=True)
+
+    # Construct the array of relative heights above the aperiodic power spectrum
+    rel_heights = np.array([ ht * np.exp(-(f - central_freq)**2/(2*bw**2)) for f in freqs])
+
+    # Build an array of the sum of squares of the cosines as they appear in the calculation of the
+    # amplitudes
+    cosine_norms = np.array([
+                          norm(
+                            np.cos(2*np.pi*f*times), 2
+                          )**2 for f in freqs
+                        ])
+
+    # Build an array of the amplitude coefficients
+    cosine_coeffs = np.array([
+                    (-np.real(sig_ap_hat[ell]) + np.sqrt(np.real(sig_ap_hat[ell])**2 + (10**rel_heights[ell] - 1)*np.abs(sig_ap_hat[ell])**2))/cosine_norms[ell]
+                    for ell in range(cosine_norms.shape[0])]
+                )
+
+    # Add cosines with the respective coefficients and with a random phase shift for each one
+    sig_periodic = np.sum(
+                    np.array(
+                        [cosine_coeffs[ell]*np.cos(2*np.pi*freqs[ell]*times + 2*np.pi*np.random.rand()) for ell in range(cosine_norms.shape[0])]
+                    ),
+                    axis=0
+                    )
+
+    sig = sig_ap + sig_periodic
 
     return sig

--- a/neurodsp/tests/sim/test_combined.py
+++ b/neurodsp/tests/sim/test_combined.py
@@ -6,6 +6,8 @@ from neurodsp.tests.settings import FS, N_SECONDS, FREQ1, FREQ2, EXP1
 from neurodsp.tests.tutils import check_sim_output
 
 from neurodsp.sim.combined import *
+from neurodsp.sim import sim_powerlaw
+from neurodsp.spectral import compute_spectrum
 
 ###################################################################################################
 ###################################################################################################
@@ -30,8 +32,15 @@ def test_sim_combined():
     with raises(ValueError):
         out = sim_combined(N_SECONDS, FS, simulations, variances)
 
-def test_sim_central_freq():
+def test_sim_peak_oscillation():
 
-    sig = sim_central_freq(N_SECONDS, FS, FREQ1, bw=5, ht=5, ap_func='sim_powerlaw',
-                           ap_kwargs={'exponent': EXP1})
+    sig_ap = sim_powerlaw(N_SECONDS, FS)
+    sig = sim_peak_oscillation(sig_ap, FS, FREQ1, bw=5, height=10)
+
     check_sim_output(sig)
+
+    # Ensure the peak is at or close (+/- 5hz) to FREQ1
+    _, powers_ap = compute_spectrum(sig_ap, FS)
+    _, powers = compute_spectrum(sig, FS)
+
+    assert abs(np.argmax(powers-powers_ap) - FREQ1) < 5

--- a/neurodsp/tests/sim/test_combined.py
+++ b/neurodsp/tests/sim/test_combined.py
@@ -2,7 +2,7 @@
 
 from pytest import raises
 
-from neurodsp.tests.settings import FS, N_SECONDS, FREQ1, FREQ2
+from neurodsp.tests.settings import FS, N_SECONDS, FREQ1, FREQ2, EXP1
 from neurodsp.tests.tutils import check_sim_output
 
 from neurodsp.sim.combined import *
@@ -29,3 +29,8 @@ def test_sim_combined():
     variances = [0.5, 1]
     with raises(ValueError):
         out = sim_combined(N_SECONDS, FS, simulations, variances)
+
+def test_sim_central_freq():
+
+    sig = sim_central_freq(N_SECONDS, FS, EXP1, FREQ1, bw=5, ht=5)
+    check_sim_output(sig)

--- a/neurodsp/tests/sim/test_combined.py
+++ b/neurodsp/tests/sim/test_combined.py
@@ -32,5 +32,6 @@ def test_sim_combined():
 
 def test_sim_central_freq():
 
-    sig = sim_central_freq(N_SECONDS, FS, EXP1, FREQ1, bw=5, ht=5)
+    sig = sim_central_freq(N_SECONDS, FS, FREQ1, bw=5, ht=5, ap_func='sim_powerlaw',
+                           ap_kwargs={'exponent': EXP1})
     check_sim_output(sig)


### PR DESCRIPTION
## Overview

This PR builds a new combined aperiodic and periodic simulation which allows the user to simulate an aperiodic component with a specified power law exponent and a single oscillatory component with specified central frequency, bandwidth, and relative height above the aperiodic component in the log-power spectrum. 

Here is a minimal working example with the analytical power spectrum superimposed for comparison.

```python
import numpy as np
import matplotlib.pyplot as plt
from neurodsp.utils.data import create_times
from neurodsp.plts import plot_power_spectra, plot_time_series
from neurodsp.sim import sim_central_freq
from neurodsp.spectral import compute_spectrum

np.random.seed(0)

n_seconds = 10
fs = 10**3
chi = -2
central_freq = 20
bw = 5
ht = 2
sig = sim_central_freq(n_seconds, fs, chi, central_freq, bw, ht)
freqs, psd = compute_spectrum(sig, fs, )#nperseg=fs*n_seconds)
times = create_times(n_seconds, fs)

# Build a reference power law to visually track if the psd has exponent chi.
psd_baseline = psd[1]/(freqs[1]**chi)*np.array([10**(ht * np.exp(-(freq - central_freq)**2/(2*bw**2))) * freq**(chi) for freq in freqs])

fig, axes = plt.subplots(2,1, figsize=(15,10))
axes[0].set_title("Aperiodic Noise with Central Frequency")
plot_time_series(times, sig, ax=axes[0])
plot_power_spectra(freqs, [psd, psd_baseline], ax=axes[1], labels=["Empirical PSD", "Reference PSD"])
plt.tight_layout()
```
![image](https://user-images.githubusercontent.com/22420689/91745180-695fba80-eb6f-11ea-84e9-08c95cc7eba8.png)

## Comments
The way the code is written is a bit limiting. For example, it doesn't allow the presence of multiple central frequencies. The code is easily adaptable to handle this case though. In general, given a signal in the time domain, this code adds sinusoids at the relevant frequencies to add a ``bump'' in the log power spectrum to the inputted signal. To get multiple central frequencies, you'd just do a few recursive calls on aperiodic noise with different central frequencies, bandwidths, and relative heights.

@ryanhammonds @TomDonoghue Do you think I should rewrite this code so that it takes as input a general time series and then adds sinusoids to augment its power spectrum, or do you think that should be a separate function and we can keep this sim as is?

## The Math Behind The Code
![image](https://user-images.githubusercontent.com/22420689/91749202-fc9bee80-eb75-11ea-9b92-da4a703fd502.png)
