### PR TITLE
[ENH] - Simulate time series with knees, sum of sinusoids

### DIFF
--- a/neurodsp/sim/__init__.py
+++ b/neurodsp/sim/__init__.py
@@ -3,7 +3,7 @@
 from neurodsp.utils.sim import set_random_seed
 
 from .periodic import sim_oscillation, sim_bursty_oscillation
-from .aperiodic import sim_powerlaw, sim_random_walk, sim_synaptic_current, sim_poisson_pop
+from .aperiodic import sim_powerlaw, sim_random_walk, sim_synaptic_current, sim_poisson_pop, sim_knee
 from .cycles import sim_cycle
 from .transients import sim_synaptic_kernel
 from .combined import sim_combined

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -116,6 +116,68 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
     return sig
 
+@normalize
+def sim_knee(n_seconds, fs, chi1, chi2, k):
+    """
+    Returns a time series whose power spectrum follows the Lorentzian equation
+
+    P(f) = 1 / (f**chi1 * (f**chi2 + k))
+
+    using a sum of sinusoids.
+
+    Parameters
+    -----------
+    n_seconds: float
+        Number of seconds elapsed in the time series.
+    fs: float
+        Sampling rate.
+    chi1: float
+        Power law exponent before the knee.
+    chi2: float
+        Power law exponent added to chi1 after the knee.
+    k: float
+        Knee parameter.
+
+    Returns
+    -------
+    sig: 1d array
+        Time series with desired power spectrum.
+
+    Notes
+    -----
+    The slope of the log power spectrum before the knee is -chi1 whereas after the knee it is -(chi1 + chi2).
+
+    Examples
+    --------
+    Simulate a time series with (chi1, chi2, k) = (1, 2, 100)
+
+    >> sim_knee(n_seconds=10, fs=10**3, chi1=1, chi2=2, k=100)
+    """
+
+    times = create_times(n_seconds, fs)
+    sig_len = fs*n_seconds
+
+    # Create the range of frequencies that appear in the power spectrum since these
+    # will be the frequencies in the cosines we sum below
+    freqs = np.linspace(0, fs/2, num=sig_len//2 + 1, endpoint=True)
+
+    # Drop the DC component
+    freqs = freqs[1:]
+
+    # Map the frequencies under the (square root) Lorentzian. This will give us the amplitude coefficients
+    # for the sinusoids.
+    cosine_coeffs = np.array([np.sqrt(1/(f**chi1*(f**chi2 + k))) for f in freqs])
+
+    # Add sinusoids with a random phase shift
+    sig = np.sum(
+                np.array(
+                    [cosine_coeffs[ell]*np.cos(2*np.pi*f*times + 2*np.pi*np.random.rand()) for ell, f in enumerate(freqs)]
+                ),
+                axis=0
+                )
+
+    return sig
+
 
 @normalize
 def sim_random_walk(n_seconds, fs, theta=1., mu=0., sigma=5.):

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -146,14 +146,14 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
 
     Notes
     -----
-    The slope of the log power spectrum before the knee is -chi1 whereas after the knee it is
-    -(chi1 + chi2).
+    The slope of the log power spectrum before the knee is chi1 whereas after the knee it is
+    (chi1 + chi2).
 
     Examples
     --------
     Simulate a time series with (chi1, chi2, knee) = (1, 2, 100)
 
-    >> sim_knee(n_seconds=10, fs=10**3, chi1=1, chi2=2, knee=100)
+    >> sim_knee(n_seconds=10, fs=10**3, chi1=-1, chi2=-2, knee=100)
     """
 
     times = create_times(n_seconds, fs)
@@ -168,7 +168,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
 
     # Map the frequencies under the (square root) Lorentzian.
     # This will give us the amplitude coefficients for the sinusoids.
-    cosine_coeffs = np.array([np.sqrt(1/(f**chi1*(f**chi2 + knee))) for f in freqs])
+    cosine_coeffs = np.array([np.sqrt(1/(f**-chi1*(f**-chi2 + knee))) for f in freqs])
 
     # Add sinusoids with a random phase shift
     sig = np.sum(

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -116,8 +116,9 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
     return sig
 
+
 @normalize
-def sim_knee(n_seconds, fs, chi1, chi2, k):
+def sim_knee(n_seconds, fs, chi1, chi2, knee):
     """
     Returns a time series whose power spectrum follows the Lorentzian equation
 
@@ -135,7 +136,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, k):
         Power law exponent before the knee.
     chi2: float
         Power law exponent added to chi1 after the knee.
-    k: float
+    knee: float
         Knee parameter.
 
     Returns
@@ -145,13 +146,14 @@ def sim_knee(n_seconds, fs, chi1, chi2, k):
 
     Notes
     -----
-    The slope of the log power spectrum before the knee is -chi1 whereas after the knee it is -(chi1 + chi2).
+    The slope of the log power spectrum before the knee is -chi1 whereas after the knee it is
+    -(chi1 + chi2).
 
     Examples
     --------
-    Simulate a time series with (chi1, chi2, k) = (1, 2, 100)
+    Simulate a time series with (chi1, chi2, knee) = (1, 2, 100)
 
-    >> sim_knee(n_seconds=10, fs=10**3, chi1=1, chi2=2, k=100)
+    >> sim_knee(n_seconds=10, fs=10**3, chi1=1, chi2=2, knee=100)
     """
 
     times = create_times(n_seconds, fs)
@@ -159,22 +161,23 @@ def sim_knee(n_seconds, fs, chi1, chi2, k):
 
     # Create the range of frequencies that appear in the power spectrum since these
     # will be the frequencies in the cosines we sum below
-    freqs = np.linspace(0, fs/2, num=sig_len//2 + 1, endpoint=True)
+    freqs = np.linspace(0, fs/2, num=int(sig_len//2 + 1), endpoint=True)
 
     # Drop the DC component
     freqs = freqs[1:]
 
-    # Map the frequencies under the (square root) Lorentzian. This will give us the amplitude coefficients
-    # for the sinusoids.
-    cosine_coeffs = np.array([np.sqrt(1/(f**chi1*(f**chi2 + k))) for f in freqs])
+    # Map the frequencies under the (square root) Lorentzian.
+    # This will give us the amplitude coefficients for the sinusoids.
+    cosine_coeffs = np.array([np.sqrt(1/(f**chi1*(f**chi2 + knee))) for f in freqs])
 
     # Add sinusoids with a random phase shift
     sig = np.sum(
-                np.array(
-                    [cosine_coeffs[ell]*np.cos(2*np.pi*f*times + 2*np.pi*np.random.rand()) for ell, f in enumerate(freqs)]
-                ),
-                axis=0
-                )
+        np.array(
+            [cosine_coeffs[ell]*np.cos(2*np.pi*f*times + 2*np.pi*np.random.rand())
+             for ell, f in enumerate(freqs)]
+        ),
+        axis=0
+    )
 
     return sig
 

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -119,10 +119,9 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
 @normalize
 def sim_knee(n_seconds, fs, chi1, chi2, knee):
-    """
-    Returns a time series whose power spectrum follows the Lorentzian equation
+    """Returns a time series whose power spectrum follows the Lorentzian equation:
 
-    P(f) = 1 / (f**chi1 * (f**chi2 + k))
+    P(f) = 1 / (f**chi1 * (f**chi2 + knee))
 
     using a sum of sinusoids.
 
@@ -137,7 +136,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     chi2: float
         Power law exponent added to chi1 after the knee.
     knee: float
-        Knee parameter.
+        Location of the knee in hz.
 
     Returns
     -------
@@ -146,12 +145,12 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
 
     Notes
     -----
-    The slope of the log power spectrum before the knee is chi1 whereas after the knee it is
-    (chi1 + chi2).
+    The slope of the log power spectrum before the knee is chi1 whereas after the knee it is chi2,
+    but only when the sign of chi1 and chi2 are the same.
 
     Examples
     --------
-    Simulate a time series with (chi1, chi2, knee) = (1, 2, 100)
+    Simulate a time series with (chi1, chi2, knee) = (-1, -2, 100)
 
     >> sim_knee(n_seconds=10, fs=10**3, chi1=-1, chi2=-2, knee=100)
     """
@@ -160,15 +159,15 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     sig_len = fs*n_seconds
 
     # Create the range of frequencies that appear in the power spectrum since these
-    # will be the frequencies in the cosines we sum below
+    #   will be the frequencies in the cosines we sum below
     freqs = np.linspace(0, fs/2, num=int(sig_len//2 + 1), endpoint=True)
 
     # Drop the DC component
     freqs = freqs[1:]
 
-    # Map the frequencies under the (square root) Lorentzian.
-    # This will give us the amplitude coefficients for the sinusoids.
-    cosine_coeffs = np.array([np.sqrt(1/(f**-chi1*(f**-chi2 + knee))) for f in freqs])
+    # Map the frequencies under the (square root) Lorentzian
+    #   This will give us the amplitude coefficients for the sinusoids
+    cosine_coeffs = np.array([np.sqrt(1/(f**-chi1*(f**(-chi2-chi1) + knee))) for f in freqs])
 
     # Add sinusoids with a random phase shift
     sig = np.sum(

--- a/neurodsp/tests/settings.py
+++ b/neurodsp/tests/settings.py
@@ -21,6 +21,8 @@ FREQ_SINE = 1
 FREQS_LST = [8, 12, 1]
 FREQS_ARR = np.array([5, 10, 15])
 EXP1 = -1
+EXP2 = -2
+KNEE = 10**2
 
 # Define error tolerance levels for test comparisons
 EPS = 10**(-10)

--- a/neurodsp/tests/sim/test_aperiodic.py
+++ b/neurodsp/tests/sim/test_aperiodic.py
@@ -1,6 +1,6 @@
 """Test aperiodic simulation functions."""
 
-from neurodsp.tests.settings import FS, N_SECONDS
+from neurodsp.tests.settings import FS, N_SECONDS, N_SECONDS_LONG, EXP1, EXP2, KNEE, EPS
 from neurodsp.tests.tutils import check_sim_output
 
 from neurodsp.sim.aperiodic import *
@@ -18,6 +18,30 @@ def test_sim_synaptic_current():
 
     sig = sim_synaptic_current(N_SECONDS, FS)
     check_sim_output(sig)
+
+def test_sim_knee():
+
+    # Use positive inputs for the exponents
+    chi1 = -EXP1
+    chi2 = -EXP2
+
+    # Build the signal and run a smoke test
+    sig = sim_knee(N_SECONDS, FS, chi1, chi2, KNEE)
+    check_sim_output(sig)
+
+    # Check against the power spectrum when you take the Fourier transform
+    sig_len = int(FS*N_SECONDS)
+    freqs = np.linspace(0, FS/2, num=sig_len//2, endpoint=True)
+
+    # Ignore the DC component to avoid division by zero in the Lorentzian
+    freqs = freqs[1:]
+    true_psd = np.array([1/(f**chi1*(f**chi2 + KNEE)) for f in freqs])
+
+    # Only look at the frequencies (ignoring DC component) up to the nyquist rate
+    sig_hat = np.fft.fft(sig)[1:sig_len//2]
+    numerical_psd = np.abs(sig_hat)**2
+
+    np.allclose(true_psd, numerical_psd, atol=EPS)
 
 def test_sim_random_walk():
 

--- a/neurodsp/tests/sim/test_aperiodic.py
+++ b/neurodsp/tests/sim/test_aperiodic.py
@@ -21,9 +21,9 @@ def test_sim_synaptic_current():
 
 def test_sim_knee():
 
-    # Use positive inputs for the exponents
-    chi1 = -EXP1
-    chi2 = -EXP2
+    # Use negative inputs for the exponents
+    chi1 = EXP1
+    chi2 = EXP2
 
     # Build the signal and run a smoke test
     sig = sim_knee(N_SECONDS, FS, chi1, chi2, KNEE)
@@ -35,7 +35,7 @@ def test_sim_knee():
 
     # Ignore the DC component to avoid division by zero in the Lorentzian
     freqs = freqs[1:]
-    true_psd = np.array([1/(f**chi1*(f**chi2 + KNEE)) for f in freqs])
+    true_psd = np.array([1/(f**-chi1*(f**(-chi2-chi1) + KNEE)) for f in freqs])
 
     # Only look at the frequencies (ignoring DC component) up to the nyquist rate
     sig_hat = np.fft.fft(sig)[1:sig_len//2]


### PR DESCRIPTION
## Overview

This simulation builds a time series out of sums of sinusoids whose power spectrum follows the Lorentzian law

P(f) = 1/(f^chi1 * (f^chi2 + k).

Below is a minimal working example.
```python
import numpy as np
from neurodsp.plts import plot_time_series, plot_power_spectra
from neurodsp.utils.data import create_times
from neurodsp.spectral import compute_spectrum
from neurodsp.sim import sim_knee
import matplotlib.pyplot as plt

n_seconds = 10
fs = 10**3
sig_len=n_seconds*fs
chi1 = 1
chi2= 2
k = 10**2
times = create_times(n_seconds, fs)

sig = sim_knee(n_seconds, fs, chi1, chi2, k)
freqs, psd = compute_spectrum(sig, fs)

# Drop the DC component
freqs, psd = freqs[1:], psd[1:]

# Plot against baseline
psd_baseline = np.array([1/(f**chi1*(f**chi2 + k)) for f in freqs])
psd_baseline *= psd[0]/psd_baseline[0]

fig, axes = plt.subplots(2,1, figsize=(15,7))
axes[0].set_title(rf"Knee Signal with Lorentzian $P(f) = \frac{{1}}{{f^{chi1}(f^{chi2} + {k})}}$")
plot_time_series(times, sig, ax=axes[0])
plot_power_spectra(freqs, [psd, psd_baseline], labels=["Empirical PSD", "Lorentzian"], ax=axes[1])
```
![knee_signal](https://user-images.githubusercontent.com/22420689/92151991-d88b1800-edd6-11ea-9659-d3bc933f481d.png)

## Comments

This code is general enough to allow shaping the power spectrum according to any pre-defined function over frequencies. This could be an extension of the code.