### PR TITLE
[WIP/ENH] Filter Report

### DIFF
--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -10,7 +10,8 @@ from neurodsp.filt.iir import filter_signal_iir
 
 def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
                   n_cycles=3, n_seconds=None, remove_edges=True, butterworth_order=None,
-                  print_transitions=False, plot_properties=False, return_filter=False):
+                  print_transitions=False, plot_properties=False, return_filter=False,
+                  verbose=False):
     """Apply a bandpass, bandstop, highpass, or lowpass filter to a neural signal.
 
     Parameters
@@ -52,6 +53,8 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
         If True, plot the properties of the filter, including frequency response and/or kernel.
     return_filter : bool, optional, default: False
         If True, return the filter coefficients.
+    verbose : bool, optional, default: False
+        If True, print out detailed filter information.
 
     Returns
     -------
@@ -74,12 +77,12 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
     if filter_type.lower() == 'fir':
         return filter_signal_fir(sig, fs, pass_type, f_range, n_cycles, n_seconds,
                                  remove_edges, print_transitions,
-                                 plot_properties, return_filter)
+                                 plot_properties, return_filter, verbose=verbose)
     elif filter_type.lower() == 'iir':
         _iir_checks(n_seconds, butterworth_order, remove_edges)
         return filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
                                  print_transitions, plot_properties,
-                                 return_filter)
+                                 return_filter, verbose=verbose)
     else:
         raise ValueError('Filter type not understood.')
 

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -14,7 +14,8 @@ from neurodsp.filt.checks import (check_filter_definition, check_filter_properti
 ###################################################################################################
 
 def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, remove_edges=True,
-                      print_transitions=False, plot_properties=False, return_filter=False):
+                      print_transitions=False, plot_properties=False, return_filter=False,
+                      verbose=False):
     """Apply an FIR filter to a signal.
 
     Parameters
@@ -48,6 +49,8 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
         If True, plot the properties of the filter, including frequency response and/or kernel.
     return_filter : bool, optional, default: False
         If True, return the filter coefficients of the FIR filter.
+    verbose : bool, optional, default: False
+        If True, print out detailed filter information.
 
     Returns
     -------
@@ -78,7 +81,8 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
     check_filter_length(sig.shape[-1], len(filter_coefs))
 
     # Check filter properties: compute transition bandwidth & run checks
-    check_filter_properties(filter_coefs, 1, fs, pass_type, f_range, verbose=print_transitions)
+    check_filter_properties(filter_coefs, 1, fs, pass_type, f_range, filt_type="FIR",
+                            verbose=np.any([print_transitions, verbose]))
 
     # Remove any NaN on the edges of 'sig'
     sig, sig_nans = remove_nans(sig)

--- a/neurodsp/filt/iir.py
+++ b/neurodsp/filt/iir.py
@@ -1,5 +1,6 @@
 """Filter signals with IIR filters."""
 
+import numpy as np
 from scipy.signal import butter, sosfiltfilt
 
 from neurodsp.utils import remove_nans, restore_nans
@@ -10,8 +11,8 @@ from neurodsp.plts.filt import plot_frequency_response
 ###################################################################################################
 ###################################################################################################
 
-def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
-                      print_transitions=False, plot_properties=False, return_filter=False):
+def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order, print_transitions=False,
+                       plot_properties=False, return_filter=False, verbose=False):
     """Apply an IIR filter to a signal.
 
     Parameters
@@ -41,6 +42,8 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
         If True, plot the properties of the filter, including frequency response and/or kernel.
     return_filter : bool, optional, default: False
         If True, return the second order series coefficients of the IIR filter.
+    verbose : bool, optional, default: False
+        If True, print out detailed filter information.
 
     Returns
     -------
@@ -65,7 +68,8 @@ def filter_signal_iir(sig, fs, pass_type, f_range, butterworth_order,
     sos = design_iir_filter(fs, pass_type, f_range, butterworth_order)
 
     # Check filter properties: compute transition bandwidth & run checks
-    check_filter_properties(sos, None, fs, pass_type, f_range, verbose=print_transitions)
+    check_filter_properties(sos, None, fs, pass_type, f_range, filt_type="IIR",
+                            verbose=np.any([print_transitions, verbose]))
 
     # Remove any NaN on the edges of 'sig'
     sig, sig_nans = remove_nans(sig)

--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -136,7 +136,7 @@ def compute_pass_band(fs, pass_type, f_range):
     return pass_bw
 
 
-def compute_transition_band(f_db, db, low=-20, high=-3):
+def compute_transition_band(f_db, db, low=-20, high=-3, return_freqs=False):
     """Compute transition bandwidth of a filter.
 
     Parameters
@@ -149,11 +149,15 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
         The lower limit that defines the transition band, in dB.
     high : float, optional, default: -3
         The upper limit that defines the transition band, in dB.
+    return_freqs : bool, optional, default: False
+        Whether to return a tuple of (lower, upper) frequency bounds for the transition band.
 
     Returns
     -------
     transition_band : float
         The transition bandwidth of the filter.
+    f_range : tuple of (float, float), optional, default: False
+        The lower and upper frequencies of the transition band.
 
     Examples
     --------
@@ -178,7 +182,15 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
     # This gets the indices of transitions to the values in searched for range
     inds = np.where(np.diff(np.logical_and(db > low, db < high)))[0]
     # This steps through the indices, in pairs, selecting from the vector to select from
-    transition_band = np.max([(b - a) for a, b in zip(f_db[inds[0::2]], f_db[inds[1::2]])])
+    transition_pairs = [(a, b) for a, b in zip(f_db[inds[0::2]], f_db[inds[1::2]])]
+    pair_idx = np.argmax([(tran[1] - tran[0]) for tran in transition_pairs])
+    f_lo = transition_pairs[pair_idx][0]
+    f_hi = transition_pairs[pair_idx][1]
+    transition_band = f_hi - f_lo
+
+    if return_freqs:
+
+        return transition_band, (f_lo, f_hi)
 
     return transition_band
 


### PR DESCRIPTION
Related to #229 and #139. This PR adds a `verbose` arg to `filter_signal`, `filter_signal_fir` and `filter_signal_iir` that prints out the filter information (suggested in Widmann et al 2015). This includes:

- Filter type (high-pass, low-pass, band-pass, band-stop, FIR, IIR)
- Cutoff frequency (including definition)
- Filter order (or length)
- Roll-off or transition bandwidth
- Passband ripple and stopband attenuation
- Filter delay (zero-phase, linear-phase, non-linear phase) and causality
- Direction of computation (one-pass forward/reverse, or two-pass forward and reverse)

The previous `print_transitions` argument functions the same as the verbose arg now (i.e. `verbose=np.any([print_transitions, verbose])`). I can fully deprecate this arg or modify it to only print transitions.

I'm not sure if the last three bullets are determined correctly (they probably aren't). I'll have to revisit to sort this out.