### PR TITLE
[BUG] Fix sim_knee accuracy test

### DIFF
--- a/neurodsp/tests/sim/test_aperiodic.py
+++ b/neurodsp/tests/sim/test_aperiodic.py
@@ -48,7 +48,7 @@ def test_sim_knee():
     np.allclose(true_psd, numerical_psd, atol=EPS)
 
     # Accuracy test for a single exponent
-    sig = sim_knee(n_seconds=N_SECONDS, fs=FS, chi1=0, chi2=EXP2, knee=KNEE)
+    sig = sim_knee(n_seconds=N_SECONDS_LONG, fs=1000, chi1=0, chi2=EXP2, knee=KNEE)
 
     freqs, powers = compute_spectrum(sig, FS, f_range=(1, 200))
 


### PR DESCRIPTION
Related to #236. The original test used `n_seconds=1` and `fs=100`, while specifying a knee at 100hz. This lead to unstable estimates of the post knee slope (causing it's accuracy test to fail) - since the max freq that could be returned from `compute_spectrum` was 50hz. Tests would randomly pass/fail depending on seed. Increasing `n_seconds` to 10 and `fs` to 1000 fixed the issue.