### PR TITLE
[ENH] - Update approach for simulating bursts

### DIFF
--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -5,6 +5,7 @@ from scipy.signal import gaussian, sawtooth
 
 from neurodsp.sim.info import get_sim_func
 from neurodsp.utils.checks import check_param
+from neurodsp.utils.decorators import normalize
 from neurodsp.sim.transients import sim_synaptic_kernel
 
 ###################################################################################################
@@ -65,6 +66,12 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
     cycle = cycle_func(n_seconds, fs, **cycle_params)
 
     return cycle
+
+
+@normalize
+def sim_normalized_cycle(n_seconds, fs, cycle_type, **cycle_params):
+    return sim_cycle(n_seconds, fs, cycle_type, **cycle_params)
+sim_normalized_cycle.__doc__ = sim_cycle.__doc__
 
 
 def sim_sine_cycle(n_seconds, fs):

--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -3,9 +3,8 @@
 import numpy as np
 from scipy.signal import gaussian, sawtooth
 
-from neurodsp.utils.checks import check_param
-from neurodsp.utils.data import calc_nsamples
 from neurodsp.sim.info import get_sim_func
+from neurodsp.utils.checks import check_param
 from neurodsp.sim.transients import sim_synaptic_kernel
 
 ###################################################################################################
@@ -128,7 +127,7 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
     check_param(rdsym, 'rdsym', [0., 1.])
 
     # Determine number of samples in rise and decay periods
-    n_samples = calc_nsamples(n_seconds, fs)
+    n_samples = int(n_seconds * fs)
     n_rise = int(np.round(n_samples * rdsym))
     n_decay = n_samples - n_rise
 
@@ -200,7 +199,7 @@ def sim_gaussian_cycle(n_seconds, fs, std):
     >>> cycle = sim_gaussian_cycle(n_seconds=0.2, fs=500, std=0.025)
     """
 
-    cycle = gaussian(calc_nsamples(n_seconds, fs), std * fs)
+    cycle = gaussian(int(n_seconds * fs), std * fs)
 
     return cycle
 
@@ -239,7 +238,7 @@ def create_cycle_time(n_seconds, fs):
     >>> indices = create_cycle_time(n_seconds=1, fs=500)
     """
 
-    return 2 * np.pi * 1 / n_seconds * (np.arange(fs * n_seconds) / fs)
+    return 2 * np.pi * 1 / n_seconds * (np.arange(int(fs * n_seconds)) / fs)
 
 
 def phase_shift_cycle(cycle, shift):

--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.signal import gaussian, sawtooth
 
 from neurodsp.utils.checks import check_param
+from neurodsp.utils.data import calc_nsamples
 from neurodsp.sim.info import get_sim_func
 from neurodsp.sim.transients import sim_synaptic_kernel
 
@@ -127,7 +128,7 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
     check_param(rdsym, 'rdsym', [0., 1.])
 
     # Determine number of samples in rise and decay periods
-    n_samples = int(np.round(n_seconds * fs))
+    n_samples = calc_nsamples(n_seconds, fs)
     n_rise = int(np.round(n_samples * rdsym))
     n_decay = n_samples - n_rise
 
@@ -199,7 +200,7 @@ def sim_gaussian_cycle(n_seconds, fs, std):
     >>> cycle = sim_gaussian_cycle(n_seconds=0.2, fs=500, std=0.025)
     """
 
-    cycle = gaussian(int(np.round(n_seconds * fs)), std * fs)
+    cycle = gaussian(calc_nsamples(n_seconds, fs), std * fs)
 
     return cycle
 

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -7,7 +7,7 @@ import numpy as np
 from neurodsp.utils.norm import normalize_sig
 from neurodsp.utils.checks import check_param
 from neurodsp.utils.decorators import normalize
-from neurodsp.sim.cycles import sim_cycle, phase_shift_cycle
+from neurodsp.sim.cycles import sim_cycle, sim_normalized_cycle, phase_shift_cycle
 
 ###################################################################################################
 ###################################################################################################
@@ -151,14 +151,9 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_approach='prob', burst_par
         if burst_approach == 'prob' and burst_param not in burst_params:
             burst_params[burst_param] = temp
 
-    # Grab normalization parameters, if any were provided
-    mean = cycle_params.pop('mean', 0.)
-    variance = cycle_params.pop('variance', 1.)
-
-    # Make a single cycle of an oscillation, and normalize this cycle
+    # Simulate a normalized cycle to use for bursts
     n_seconds_cycle = 1/freq
-    osc_cycle = sim_cycle(n_seconds_cycle, fs, cycle, **cycle_params)
-    osc_cycle = normalize_sig(osc_cycle, mean, variance)
+    osc_cycle = sim_normalized_cycle(n_seconds_cycle, fs, cycle, **cycle_params)
 
     # Calculate the number of cycles needed to tile the full signal
     n_cycles = int(np.floor(n_seconds * freq))

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -1,5 +1,7 @@
 """Simulating time series, with periodic activity."""
 
+from itertools import repeat
+
 import numpy as np
 
 from neurodsp.utils.norm import normalize_sig
@@ -182,5 +184,47 @@ def make_is_osc_prob(n_cycles, enter_burst, leave_burst):
         # Otherwise, with prior cycle not bursting, enter burst with given probability
         else:
             is_oscillating[ind] = rand_num < enter_burst
+
+    return is_oscillating
+
+
+def make_is_osc_durations(n_cycles, n_cycles_burst, n_cycles_off):
+    """Create bursting definition, based on cycle lengths and intervals.
+
+    Parameters
+    ----------
+    n_cycles : int
+        The number of cycles to simulate the burst definiton for.
+    n_cycles_burst : int
+        Number of cycles per burst.
+    n_cycles_off : int
+        Number of cycles between bursts.
+
+    Returns
+    -------
+    is_oscillations : 1d array of bool
+        Definition of whether each cycle is bursting or not.
+    """
+
+    # Make the burst parameters iterators
+    n_cycles_burst = repeat(n_cycles_burst) if isinstance(n_cycles_burst, int) else n_cycles_burst
+    n_cycles_off = repeat(n_cycles_off) if isinstance(n_cycles_off, int) else n_cycles_off
+
+    # Initialize is oscillating
+    is_oscillating = np.array([False] * (n_cycles))
+
+    # Set the first bursting index
+    ind = 1
+
+    # Fill in bursts
+    while ind < len(is_oscillating):
+
+        # Within a burst, set specified cycles as bursting
+        b_len = next(n_cycles_burst)
+        is_oscillating[ind: ind+b_len] = True
+
+        # Update index to the next burst start definition
+        off_len = next(n_cycles_off)
+        ind = ind + b_len + off_len
 
     return is_oscillating

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -225,7 +225,7 @@ def make_is_osc_prob(n_cycles, enter_burst, leave_burst):
     check_param(leave_burst, 'leave_burst', [0., 1.])
 
     # Initialize vector of burst definitions
-    is_oscillating = np.array([False] * (n_cycles))
+    is_oscillating = np.zeros(n_cycles, dtype=bool)
 
     for ind in range(1, n_cycles):
 
@@ -249,7 +249,7 @@ def make_is_osc_durations(n_cycles, n_cycles_burst, n_cycles_off):
     n_cycles : int
         The number of cycles to simulate the burst definition for.
     n_cycles_burst : int
-        Number of cycles within a burst burst.
+        Number of cycles within a burst.
     n_cycles_off : int
         Number of cycles between bursts.
 
@@ -264,19 +264,17 @@ def make_is_osc_durations(n_cycles, n_cycles_burst, n_cycles_off):
     n_cycles_off = repeat(n_cycles_off) if isinstance(n_cycles_off, int) else n_cycles_off
 
     # Initialize is oscillating
-    is_oscillating = np.array([False] * (n_cycles))
-
-    # Set the first bursting index
-    ind = 1
+    is_oscillating = np.zeros(n_cycles, dtype=bool)
 
     # Fill in bursts
+    ind = 0
     while ind < len(is_oscillating):
 
         # Within a burst, set specified cycles as bursting
         b_len = next(n_cycles_burst)
         is_oscillating[ind: ind+b_len] = True
 
-        # Update index to the next burst start definition
+        # Update index for the next burst
         off_len = next(n_cycles_off)
         ind = ind + b_len + off_len
 
@@ -301,11 +299,7 @@ def get_burst_samples(is_oscillating, fs, freq):
         Definition of whether each sample is part of a burst or not.
     """
 
-    n_seconds_cycle = 1/freq
-    n_samples_cycle = int(n_seconds_cycle * fs)
+    n_samples_cycle = int(1/freq * fs)
+    bursts = np.repeat(is_oscillating, n_samples_cycle)
 
-    bursts = []
-    for cycle in is_oscillating:
-        bursts.extend(n_samples_cycle * [True if cycle else False])
-
-    return np.array(bursts)
+    return bursts

--- a/neurodsp/tests/sim/test_cycles.py
+++ b/neurodsp/tests/sim/test_cycles.py
@@ -35,6 +35,11 @@ def test_sim_cycle():
     with raises(ValueError):
         sim_cycle(N_SECONDS, FS, 'not_a_cycle')
 
+def test_sim_normalized_cycle():
+
+    cycle = sim_normalized_cycle(N_SECONDS, FS, 'sine')
+    check_sim_output(cycle)
+
 def test_sim_sine_cycle():
 
     cycle = sim_sine_cycle(N_SECONDS, FS)

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -20,5 +20,13 @@ def test_sim_bursty_oscillation():
 
 def test_make_is_osc_prob():
 
-    is_osc = make_is_osc_prob(10, 0.5, 0.5)
+    is_osc = make_is_osc_prob(15, 0.5, 0.5)
     assert is_osc.dtype == 'bool'
+    assert sum(is_osc) < len(is_osc)
+
+def test_make_is_osc_durations():
+
+    is_osc = make_is_osc_durations(15, 2, 2)
+    assert is_osc.dtype == 'bool'
+    assert list(is_osc[1:3]) == [True, True]
+    assert list(is_osc[3:5]) == [False, False]

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -47,5 +47,14 @@ def test_make_is_osc_durations():
 
     is_osc = make_is_osc_durations(15, 2, 2)
     assert is_osc.dtype == 'bool'
-    assert list(is_osc[1:3]) == [True, True]
-    assert list(is_osc[3:5]) == [False, False]
+    assert list(is_osc[0:2]) == [True, True]
+    assert list(is_osc[2:4]) == [False, False]
+
+def test_get_burst_samples():
+
+    is_oscillating = np.array([False, True, True, False])
+    burst_samples = get_burst_samples(is_oscillating, FS, 10)
+
+    # First ten samples should be false & next ten samples should by true
+    assert sum(burst_samples[0:10]) == 0
+    assert sum(burst_samples[10:20]) == 10

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -29,6 +29,14 @@ def test_sim_bursty_oscillation():
         burst_approach='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
     check_sim_output(sig3)
 
+def test_make_bursts():
+
+    is_osc = np.array([False, False, True, True, False, True, False, True, True, False])
+    cycle = np.ones([10])
+
+    sig = make_bursts(N_SECONDS, FS, is_osc, cycle)
+    check_sim_output(sig)
+
 def test_make_is_osc_prob():
 
     is_osc = make_is_osc_prob(15, 0.5, 0.5)

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -15,8 +15,19 @@ def test_sim_oscillation():
 
 def test_sim_bursty_oscillation():
 
-    sig = sim_bursty_oscillation(N_SECONDS, FS, FREQ1)
-    check_sim_output(sig)
+    # Check default values work
+    sig1 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1)
+    check_sim_output(sig1)
+
+    # Check probability burst approach
+    sig2 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1, \
+        burst_approach='prob', burst_params={'enter_burst' : 0.3, 'leave_burst' : 0.3})
+    check_sim_output(sig2)
+
+    # Check durations burst approach
+    sig3 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1, \
+        burst_approach='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
+    check_sim_output(sig3)
 
 def test_make_is_osc_prob():
 

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -21,12 +21,12 @@ def test_sim_bursty_oscillation():
 
     # Check probability burst approach
     sig2 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1, \
-        burst_approach='prob', burst_params={'enter_burst' : 0.3, 'leave_burst' : 0.3})
+        burst_def='prob', burst_params={'enter_burst' : 0.3, 'leave_burst' : 0.3})
     check_sim_output(sig2)
 
     # Check durations burst approach
     sig3 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1, \
-        burst_approach='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
+        burst_def='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
     check_sim_output(sig3)
 
 def test_make_bursts():

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -4,7 +4,6 @@ from neurodsp.tests.tutils import check_sim_output
 from neurodsp.tests.settings import FS, N_SECONDS, FREQ1
 
 from neurodsp.sim.periodic import *
-from neurodsp.sim.periodic import _make_is_osc
 
 ###################################################################################################
 ###################################################################################################
@@ -19,7 +18,7 @@ def test_sim_bursty_oscillation():
     sig = sim_bursty_oscillation(N_SECONDS, FS, FREQ1)
     check_sim_output(sig)
 
-def test_make_is_osc():
+def test_make_is_osc_prob():
 
-    is_osc = _make_is_osc(10, 0.5, 0.5)
-    assert isinstance(is_osc[0], bool)
+    is_osc = make_is_osc_prob(10, 0.5, 0.5)
+    assert is_osc.dtype == 'bool'

--- a/neurodsp/tests/utils/test_data.py
+++ b/neurodsp/tests/utils/test_data.py
@@ -34,6 +34,12 @@ def test_create_samples():
     samples = create_samples(10)
     assert_equal(samples, np.arange(0, 10, 1))
 
+def test_calc_nsamples():
+
+    n_samples = calc_nsamples(1, 100)
+    assert isinstance(n_samples, int)
+    assert n_samples == 100
+
 def test_split_signal(tsig):
 
     chunks = split_signal(tsig, 100)

--- a/neurodsp/tests/utils/test_data.py
+++ b/neurodsp/tests/utils/test_data.py
@@ -36,7 +36,7 @@ def test_create_samples():
 
 def test_calc_nsamples():
 
-    n_samples = calc_nsamples(1, 100)
+    n_samples = compute_nsamples(1, 100)
     assert isinstance(n_samples, int)
     assert n_samples == 100
 

--- a/neurodsp/utils/data.py
+++ b/neurodsp/utils/data.py
@@ -44,7 +44,7 @@ def create_times(n_seconds, fs, start_val=0.):
         Time indices.
     """
 
-    return np.arange(start_val, n_seconds + start_val, 1/fs)
+    return np.linspace(start_val, n_seconds, int(fs * n_seconds)+1)[:-1]
 
 
 def create_samples(n_samples, start_val=0):
@@ -53,7 +53,7 @@ def create_samples(n_samples, start_val=0):
     Parameters
     ----------
     n_seconds : int
-        Number of sample.
+        Signal duration, in seconds.
     start_val : int, optional, default: 0
         Starting value for the samples definition.
 
@@ -66,23 +66,29 @@ def create_samples(n_samples, start_val=0):
     return np.arange(start_val, n_samples, 1)
 
 
-def calc_nsamples(n_seconds, fs):
-    """Calculate the number of samples.
+def compute_nsamples(n_seconds, fs):
+    """Calculate the number of samples for a given time definition.
 
     Parameters
     ----------
     n_seconds : int
-        Number of sample.
+        Signal duration, in seconds.
     fs : float
         Signal sampling rate, in Hz.
 
     Returns
     -------
     int
-        The number of samples needed.
+        The number of samples.
+
+    Notes
+    -----
+    The result has to be rounded, in order to ensure that the number of samples is a whole number.
+
+    The `int` function rounds down, by default, which is the convention across the module.
     """
 
-    return int(np.ceil(n_seconds * fs))
+    return int(n_seconds * fs)
 
 
 def split_signal(sig, n_samples):

--- a/neurodsp/utils/data.py
+++ b/neurodsp/utils/data.py
@@ -66,6 +66,25 @@ def create_samples(n_samples, start_val=0):
     return np.arange(start_val, n_samples, 1)
 
 
+def calc_nsamples(n_seconds, fs):
+    """Calculate the number of samples.
+
+    Parameters
+    ----------
+    n_seconds : int
+        Number of sample.
+    fs : float
+        Signal sampling rate, in Hz.
+
+    Returns
+    -------
+    int
+        The number of samples needed.
+    """
+
+    return int(np.ceil(n_seconds * fs))
+
+
 def split_signal(sig, n_samples):
     """Split a signal into non-overlapping segments.
 


### PR DESCRIPTION
This update extends the available approaches for simulating bursty oscillations.

Main updates:
- add a new approach for simulating bursts, by specifying burst lengths and inter-burst intervals
- refactor the burst code, to allow for more customizable 
- fixes to standardize that all sims of the same length get the same amount of samples, & other small fixes

Notes
- I'm not totally sure about the API here. It's currently set up in a transition state, to not change prior behaviour, while adding in the new approaches to the same burst function. Thoughts on this?
- There are a couple little things to try and anticipate more customizability, for example the 'durations' approach is set up to eventually be able to take in generator objects to sample variable parameters, but this isn't totally finished. 
- If the approach here looks good, I'll finish updating the doctests and tutorials that use the burst simulation

@ryanhammonds - for now, can have a first sweep, and see if you have any thoughts on the approach / API?