### PR TITLE
[ENH] Incomplete tile warning

### DIFF
--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -40,10 +40,10 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
 
     Notes
     -----
-    When ``freq`` and ``fs`` are not evenly divisible, there will be a non-integer number of samples
-    per cycle. In the frequency domain, this will lead to power in non-simulated frequencies.
-    Consider updating ``freq and ``fs`` to an integer divisor/multiple when investigating spectral
-    properties.
+	Depending on the requested frequency (`freq`), sampling rate (`fs`), and signal
+	length (`n_seconds`), the simulated signal may have a non-integer number of cycles.
+	If so, the frequency-domain representation of the signal will have some power in non-simulated
+	frequencies. To avoid this, choose `n_seconds` and `fs` to create an integer number of cycles.
 
     Examples
     --------

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -1,5 +1,6 @@
 """Simulating time series, with periodic activity."""
 
+import warnings
 from itertools import repeat
 
 import numpy as np
@@ -49,6 +50,9 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
     >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=15,
     ...                       cycle='asine', phase=0.5, rdsym=0.75)
     """
+
+    # Check if tiling can produce full oscillations
+    _check_tiling(fs, freq)
 
     # Figure out how many cycles are needed for the signal
     n_cycles = int(np.ceil(n_seconds * freq))
@@ -149,6 +153,9 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params={
         temp = cycle_params.pop(burst_param, 0.2)
         if burst_def == 'prob' and burst_param not in burst_params:
             burst_params[burst_param] = temp
+
+    # Check if tiling can produce full oscillations
+    _check_tiling(fs, freq)
 
     # Simulate a normalized cycle to use for bursts
     n_seconds_cycle = 1/freq
@@ -303,3 +310,15 @@ def get_burst_samples(is_oscillating, fs, freq):
     bursts = np.repeat(is_oscillating, n_samples_cycle)
 
     return bursts
+
+
+def _check_tiling(fs, freq):
+    """Check if tiling can produce full oscillations."""
+
+    if not (fs/freq).is_integer():
+
+        warnings.warn('''
+        The requested frequency and sampling rate are not evenly divisible, resulting
+        in an artifactual spectral slope. Consider updating freq and fs to an integer
+        divisor/multiple pair.
+        ''', category=RuntimeWarning)

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -1,6 +1,5 @@
 """Simulating time series, with periodic activity."""
 
-import warnings
 from itertools import repeat
 
 import numpy as np
@@ -39,6 +38,13 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
     sig : 1d array
         Simulated oscillation.
 
+    Notes
+    -----
+    When ``freq`` and ``fs`` are not evenly divisible, there will be a non-integer number of samples
+    per cycle. In the frequency domain, this will lead to power in non-simulated frequencies.
+    Consider updating ``freq and ``fs`` to an integer divisor/multiple when investigating spectral
+    properties.
+
     Examples
     --------
     Simulate a continuous sinusoidal oscillation at 5 Hz:
@@ -50,9 +56,6 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
     >>> sig = sim_oscillation(n_seconds=1, fs=500, freq=15,
     ...                       cycle='asine', phase=0.5, rdsym=0.75)
     """
-
-    # Check if tiling can produce full oscillations
-    _check_tiling(fs, freq)
 
     # Figure out how many cycles are needed for the signal
     n_cycles = int(np.ceil(n_seconds * freq))
@@ -153,9 +156,6 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params={
         temp = cycle_params.pop(burst_param, 0.2)
         if burst_def == 'prob' and burst_param not in burst_params:
             burst_params[burst_param] = temp
-
-    # Check if tiling can produce full oscillations
-    _check_tiling(fs, freq)
 
     # Simulate a normalized cycle to use for bursts
     n_seconds_cycle = 1/freq
@@ -310,15 +310,3 @@ def get_burst_samples(is_oscillating, fs, freq):
     bursts = np.repeat(is_oscillating, n_samples_cycle)
 
     return bursts
-
-
-def _check_tiling(fs, freq):
-    """Check if tiling will produce an integer number of cycles for the simulated oscillation."""
-
-    if not (fs/freq).is_integer():
-
-        warnings.warn('''
-        The settings for the frequency and sampling rate are not evenly divisible. In the frequency
-        domain, this can lead to power in non-simulated frequencies in the power spectrum. Consider
-        updating freq and fs to an integer divisor/multiple pair."
-        ''', category=RuntimeWarning)

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -313,12 +313,12 @@ def get_burst_samples(is_oscillating, fs, freq):
 
 
 def _check_tiling(fs, freq):
-    """Check if tiling can produce full oscillations."""
+    """Check if tiling will produce an integer number of cycles for the simulated oscillation."""
 
     if not (fs/freq).is_integer():
 
         warnings.warn('''
-        The requested frequency and sampling rate are not evenly divisible, resulting
-        in an artifactual spectral slope. Consider updating freq and fs to an integer
-        divisor/multiple pair.
+        The settings for the frequency and sampling rate are not evenly divisible. In the frequency
+        domain, this can lead to power in non-simulated frequencies in the power spectrum. Consider
+        updating freq and fs to an integer divisor/multiple pair."
         ''', category=RuntimeWarning)

--- a/neurodsp/sim/utils.py
+++ b/neurodsp/sim/utils.py
@@ -1,0 +1,30 @@
+"""Utility functions for simulations."""
+
+###################################################################################################
+###################################################################################################
+
+def check_osc_def(n_seconds, fs, freq):
+    """Check whether a requested oscillation definition will have an integer number of cycles.
+
+    Parameters
+    ----------
+    n_seconds : float
+        Simulation time, in seconds.
+    fs : float
+        Signal sampling rate, in Hz.
+    freq : float
+        Oscillation frequency.
+
+    Returns
+    -------
+    bool
+        Whether the definition will have an integer number of cycles.
+    """
+
+    # Sampling rate check: check if the number of samples per cycle is an integer
+    srate_check = (fs/freq).is_integer()
+
+    # Time check: check if signal length matches an integer number of cycles
+    time_check = (n_seconds * freq).is_integer()
+
+    return srate_check and time_check

--- a/neurodsp/tests/sim/test_utils.py
+++ b/neurodsp/tests/sim/test_utils.py
@@ -1,0 +1,24 @@
+"""Tests for neurodsp.sim.utils."""
+
+from neurodsp.sim.utils import *
+
+###################################################################################################
+###################################################################################################
+
+def test_check_osc_def():
+
+	n_seconds = 1.0
+	fs = 100
+	freq = 10
+
+	# Check definition that should pass
+	assert check_osc_def(n_seconds, fs, freq)
+
+	# Check a definition that should fail the sampling rate check
+	assert not check_osc_def(1.05, fs, freq)
+
+	# Check a definition that should fail the time check
+	assert not check_osc_def(n_seconds, 1111, freq)
+
+	# Check a definition that should fail both checks
+	assert not check_osc_def(1.05, 1111, freq)


### PR DESCRIPTION
This adds a tile warning addressing #223, so noobs like myself aren't confused when a slope in the spectrum results from `sim_oscillation` (i.e. fs/freq is not an int). The slope below use to be smooth but now it produces a decreasing slope of harmonics.

```python
from neurodsp.sim import sim_oscillation
from neurodsp.spectral import compute_spectrum
from neurodsp.plts import plot_power_spectra


n_seconds = 100
fs = 1000
freq = 9

sig = sim_oscillation(n_seconds, fs, freq)

freqs, powers = compute_spectrum(sig, fs)

plot_power_spectra(freqs, powers)
```