### PR TITLE
[ENH] - Add support for passing in a callable to sim_cycle

### DIFF
--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -21,7 +21,7 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
         This is NOT the period of the cycle, but the length of the returned array of the cycle.
     fs : float
         Sampling frequency of the cycle simulation.
-    cycle_type : {'sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp'}
+    cycle_type : {'sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp'} or callable
         What type of cycle to simulate. Options:
 
         * sine: a sine wave cycle

--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -62,7 +62,11 @@ def sim_cycle(n_seconds, fs, cycle_type, **cycle_params):
     is accessible by this function. The `cycle_type` input must match the label.
     """
 
-    cycle_func = get_sim_func('sim_' + cycle_type + '_cycle', modules=['cycles'])
+    if isinstance(cycle_type, str):
+        cycle_func = get_sim_func('sim_' + cycle_type + '_cycle', modules=['cycles'])
+    else:
+        cycle_func = cycle_type
+
     cycle = cycle_func(n_seconds, fs, **cycle_params)
 
     return cycle

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -24,7 +24,7 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
         Signal sampling rate, in Hz.
     freq : float
         Oscillation frequency.
-    cycle : {'sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp'}
+    cycle : {'sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp'} or callable
         What type of oscillation cycle to simulate.
         See `sim_cycle` for details on cycle types and parameters.
     phase : float, optional, default: 0


### PR DESCRIPTION
This update allows for passing in a callable to `sim_cycle`. 

This is to make it easier to explore new cycle types. In particular, this means a callable can be passed through from `sim_oscillation`. I think this useful to be able to be able to explore and test new cycles and tiling, without having to add them to the module. If the function is well formed as a cycle function, it gets called, with any passed in parameters. 

Consider the following example that will now work:
```
from neurodsp.sim import sim_oscillation
def sim_offset_sine(n_seconds, fs, offset):

    cycle = np.sin(2 * np.pi * 1 / n_seconds * (np.arange(int(fs * n_seconds)) / fs))
    cycle = cycle + offset

    return cycle

n_seconds, fs, freq = 1, 1000, 10
osc = sim_oscillation(n_seconds, fs, freq, sim_offset_sine, offset=1, mean=None)
# Note: passing in the `mean` param is just to turn off normalization.
```