### PR TITLE
[ENH] Simulate variable oscillations

### DIFF
--- a/neurodsp/sim/__init__.py
+++ b/neurodsp/sim/__init__.py
@@ -2,7 +2,7 @@
 
 from neurodsp.utils.sim import set_random_seed
 
-from .periodic import sim_oscillation, sim_bursty_oscillation
+from .periodic import sim_oscillation, sim_bursty_oscillation, sim_variable_oscillation
 from .aperiodic import sim_powerlaw, sim_random_walk, sim_synaptic_current, sim_poisson_pop, sim_knee
 from .cycles import sim_cycle
 from .transients import sim_synaptic_kernel

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -73,12 +73,13 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
 
         # If list, params should be a list of separate parameters for each function call
         if isinstance(params, list):
-            sig_components.extend([func(n_seconds, fs, **cur_params, variance=next(variances)) \
-                for cur_params in params])
+            sig_components.extend([func(n_seconds=n_seconds, fs=fs, **cur_params,
+                                        variance=next(variances)) for cur_params in params])
 
         # Otherwise, params should be a dictionary of parameters for single call
         else:
-            sig_components.append(func(n_seconds, fs, **params, variance=next(variances)))
+            sig_components.append(func(n_seconds=n_seconds, fs=fs, **params,
+                                       variance=next(variances)))
 
     # Combine total signal across all simulated components
     sig = np.sum(sig_components, axis=0)

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -180,19 +180,19 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params=N
 
 
 @normalize
-def sim_variable_oscillation(fs, freqs, n_seconds='auto', cycle='sine', phase=0, **cycle_params):
+def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycle_params):
     """Simulate an oscillation that varies in frequency and cycle parameters.
 
     Parameters
     ----------
+    n_seconds : float or None
+        Simulation time, in seconds. If None, the simulation time is based on `freqs` and the
+        length of `cycle_params`. If a float, the signal may be truncated or contain trailing zeros
+        if not exact.
     fs : float
         Signal sampling rate, in Hz.
     freqs : float or list
         Oscillation frequencies.
-    n_seconds : 'auto' or float, optional, default: 'auto'
-        Simulation time, in seconds. If 'auto', the simulation time is based on `freqs` and the
-        length of `cycle_params`. If a float, the signal may be truncated or contain trailing zeros
-        if not exact.
     cycle : {'sine', 'asine', 'sawtooth', 'gaussian', 'exp', '2exp'} or callable
         Type of oscillation cycle to simulate.
         See `sim_cycle` for details on cycle types and parameters.
@@ -250,12 +250,12 @@ def sim_variable_oscillation(fs, freqs, n_seconds='auto', cycle='sine', phase=0,
     cycle_params = [{}] * len(freqs) if len(cycle_params) == 0 else cycle_params
 
     # Determine start/end indices
-    cyc_lens = [len(create_cycle_time((1 / freq), fs)) for freq in freqs]
+    cyc_lens = [int(np.ceil(1 / freq * fs)) for freq in freqs]
     ends = np.cumsum(cyc_lens, dtype=int)
     starts = [0, *ends[:-1]]
 
     # Simulate
-    n_samples = np.sum(cyc_lens) if n_seconds == 'auto' else int(n_seconds * fs)
+    n_samples = np.sum(cyc_lens) if n_seconds is None else compute_nsamples(n_seconds, fs)
 
     sig = np.zeros(n_samples)
 

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -179,7 +179,6 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params=N
     return sig
 
 
-@normalize
 def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycle_params):
     """Simulate an oscillation that varies in frequency and cycle parameters.
 
@@ -265,7 +264,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
             break
 
         n_seconds_cycle = int(np.ceil(fs / freq)) / fs
-        sig[start:end] = sim_cycle(n_seconds_cycle, fs, cycle, phase, **params)
+        sig[start:end] = sim_normalized_cycle(n_seconds_cycle, fs, cycle, phase, **params)
 
     return sig
 

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -1,5 +1,7 @@
 """Tests for neurodsp.sim.periodic."""
 
+from pytest import raises
+
 from neurodsp.tests.tutils import check_sim_output
 from neurodsp.tests.settings import FS, N_SECONDS, FREQ1, N_SECONDS_ODD, FS_ODD
 
@@ -64,6 +66,27 @@ def test_sim_bursty_oscillation():
     sig3 = sim_bursty_oscillation(N_SECONDS, FS, FREQ1, \
         burst_def='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
     check_sim_output(sig3)
+
+
+def test_sim_variable_oscillation():
+
+    freqs = np.array([10, 20])
+    rdsyms = [.4, .8]
+
+    sig1 = sim_variable_oscillation(FS, freqs, cycle='asine', rdsym=rdsyms)
+    assert isinstance(sig1, np.ndarray) and len(sig1) == sum(FS/freqs) and ~np.isnan(sig1).any()
+
+    sig2 = sim_variable_oscillation(FS, 20, cycle='asine', rdsym=rdsyms)
+    assert isinstance(sig2, np.ndarray) and len(sig2) == 2 * FS / 20 and ~np.isnan(sig2).any()
+
+    # Too few frequencies
+    with raises(ValueError):
+        sig3 = sim_variable_oscillation(FS, freqs[1:], cycle='asine', rdsym=rdsyms)
+
+    # Too few params
+    with raises(ValueError):
+        sig4 = sim_variable_oscillation(FS, freqs, cycle='asine', rdsym=rdsyms[1:])
+
 
 def test_make_bursts():
 

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -73,19 +73,19 @@ def test_sim_variable_oscillation():
     freqs = np.array([10, 20])
     rdsyms = [.4, .8]
 
-    sig1 = sim_variable_oscillation(FS, freqs, cycle='asine', rdsym=rdsyms)
+    sig1 = sim_variable_oscillation(None, FS, freqs, cycle='asine', rdsym=rdsyms)
     assert isinstance(sig1, np.ndarray) and len(sig1) == sum(FS/freqs) and ~np.isnan(sig1).any()
 
-    sig2 = sim_variable_oscillation(FS, 20, cycle='asine', rdsym=rdsyms)
+    sig2 = sim_variable_oscillation(None, FS, 20, cycle='asine', rdsym=rdsyms)
     assert isinstance(sig2, np.ndarray) and len(sig2) == 2 * FS / 20 and ~np.isnan(sig2).any()
 
     # Too few frequencies
     with raises(ValueError):
-        sig3 = sim_variable_oscillation(FS, freqs[1:], cycle='asine', rdsym=rdsyms)
+        sig3 = sim_variable_oscillation(None, FS, freqs[1:], cycle='asine', rdsym=rdsyms)
 
     # Too few params
     with raises(ValueError):
-        sig4 = sim_variable_oscillation(FS, freqs, cycle='asine', rdsym=rdsyms[1:])
+        sig4 = sim_variable_oscillation(None, FS, freqs, cycle='asine', rdsym=rdsyms[1:])
 
 
 def test_make_bursts():


### PR DESCRIPTION
This allows the frequency and/or simulation kwarg(s) to vary on a cycle-by-cycle basis.

```python
import numpy as np
from neurodsp.sim import sim_variable_oscillation
from neurodsp.plts import plot_time_series

fs = 1000

freqs = [ 5, 10, 15, 20]
rdsyms= [.2, .4, .6, .8]

sig = sim_variable_oscillation(fs, freqs, cycle='asine', rdsym=rdsyms)
times = np.arange(0, len(sig)/fs, 1/fs)

plot_time_series(times, sig)
```
![Screenshot_20210223_173332](https://user-images.githubusercontent.com/34786005/108931938-62d16d80-75fd-11eb-878f-72fe7da389a1.png)
