### PR TITLE
[ENH] - Add one sided asymmetric option to asine cycle

### DIFF
--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -111,7 +111,7 @@ def sim_sine_cycle(n_seconds, fs):
     return cycle
 
 
-def sim_asine_cycle(n_seconds, fs, rdsym):
+def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
     """Simulate a cycle of an asymmetric sine wave.
 
     Parameters
@@ -127,6 +127,8 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
         = 0.5 - symmetric (sine wave)
         < 0.5 - shorter rise, longer decay
         > 0.5 - longer rise, shorter decay
+    side : {'both', 'peak', 'trough'}
+        Which side of the cycle to make asymmetric.
 
     Returns
     -------
@@ -145,16 +147,33 @@ def sim_asine_cycle(n_seconds, fs, rdsym):
     # Determine number of samples in rise and decay periods
     n_samples = int(n_seconds * fs)
     n_rise = int(np.round(n_samples * rdsym))
-    n_decay = n_samples - n_rise
 
-    # Make phase array for an asymmetric cycle
-    #   Note: the ceil & floor are so the cycle has the right number of samples if n_decay is odd
-    phase = np.hstack([np.linspace(0, np.pi/2, int(np.ceil(n_rise/2)) + 1),
-                       np.linspace(np.pi/2, -np.pi/2, n_decay + 1)[1:-1],
-                       np.linspace(-np.pi/2, 0, int(np.floor(n_rise/2)) + 1)[:-1]])
+    if side == 'both':
+
+        n_decay = n_samples - n_rise
+
+        # Make phase array for an asymmetric cycle
+        #   Note: the ceil & floor are so the cycle has the right number of samples if n_decay is odd
+        phase = np.hstack([np.linspace(0, np.pi/2, int(np.ceil(n_rise/2)) + 1),
+                           np.linspace(np.pi/2, -np.pi/2, n_decay + 1)[1:-1],
+                           np.linspace(-np.pi/2, 0, int(np.floor(n_rise/2)) + 1)[:-1]])
+
+    if side in ['peak', 'trough']:
+
+        half_sample = int(n_samples/2)
+
+        npts = int(np.ceil(n_rise/2)) + 1
+        offset = (1/half_sample * np.pi)
+
+        phase = np.hstack([np.linspace(0, np.pi/2, npts),
+                           np.linspace(np.pi/2, np.pi, half_sample-npts),
+                           np.linspace(np.pi + offset, 2*np.pi, half_sample + 1)[:-1]])
 
     # Convert phase definition to signal
     cycle = np.sin(phase)
+
+    if side == 'trough':
+        cycle = -1 * phase_shift_cycle(cycle, 0.5)
 
     return cycle
 

--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -150,37 +150,39 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
     half_sample = int(n_samples/2)
 
     # Calculate number of samples rising
-    n_rise_tot = int(np.round(n_samples * rdsym))
-    n_rise_start = int(np.ceil(n_rise_tot/2))
-    n_rise_end = int(np.floor(n_rise_tot/2))
+    n_rise = int(np.round(n_samples * rdsym))
+    n_rise1 = int(np.ceil(n_rise/2))
+    n_rise2 = int(np.floor(n_rise/2))
 
     # Calculate number of samples decaying
-    n_decay_full = n_samples - n_rise_tot
-    n_decay_half = half_sample - n_rise_start
-
-    # Calculate step size of one sample, to offset ranges, as needed
-    offset = (1/n_samples * 2*np.pi)
+    n_decay = n_samples - n_rise
+    n_decay1 = half_sample - n_rise1
 
     # Create phase defintion for cycle with both extrema being asymmetric
     if side == 'both':
 
-        phase = np.hstack([np.linspace(0, np.pi/2, n_rise_start),
-                           np.linspace(np.pi/2 + offset, -np.pi/2, n_decay_full),
-                           np.linspace(-np.pi/2 + offset, 0-offset, n_rise_end)])
+        phase = np.hstack([np.linspace(0, np.pi/2, n_rise1 + 1),
+                           np.linspace(np.pi/2, -np.pi/2, n_decay + 1)[1:-1],
+                           np.linspace(-np.pi/2, 0, n_rise2 + 1)[:-1]])
 
     # Create phase defintion for cycle with only one extrema being asymmetric
-    if side in ['peak', 'trough']:
+    elif side == 'peak':
 
-        phase = np.hstack([np.linspace(0, np.pi/2, n_rise_start),
-                           np.linspace(np.pi/2, np.pi, n_decay_half),
-                           np.linspace(np.pi + offset, 2*np.pi-offset, half_sample)])
+        phase = np.hstack([np.linspace(0, np.pi/2, n_rise1 + 1),
+                           np.linspace(np.pi/2, np.pi, n_decay1 + 1)[1:-1],
+                           np.linspace(-np.pi, 0, half_sample + 1)[:-1]])
+
+    elif side == 'trough':
+
+        phase = np.hstack([np.linspace(0, np.pi, half_sample + 1)[:-1],
+                           np.linspace(-np.pi, -np.pi/2, n_decay1 + 1),
+                           np.linspace(-np.pi/2, 0, n_rise1 + 1)[:-1]])
+
+    else:
+        raise ValueError("Input for 'side' not understood.")
 
     # Convert phase definition to signal
     cycle = np.sin(phase)
-
-    # For asymmetric trough, rotate and flip the generated cycle
-    if side == 'trough':
-        cycle = -1 * phase_shift_cycle(cycle, 0.5)
 
     return cycle
 

--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -144,34 +144,40 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
 
     check_param_range(rdsym, 'rdsym', [0., 1.])
 
-    # Determine number of samples in rise and decay periods
+    # Determine number of samples
     n_samples = int(n_seconds * fs)
-    n_rise = int(np.round(n_samples * rdsym))
+    half_sample = int(n_samples/2)
 
+    # Calculate number of samples rising
+    n_rise_tot = int(np.round(n_samples * rdsym))
+    n_rise_start = int(np.ceil(n_rise_tot/2))
+    n_rise_end = int(np.floor(n_rise_tot/2))
+
+    # Calculate number of samples decaying
+    n_decay_full = n_samples - n_rise_tot
+    n_decay_half = half_sample - n_rise_start
+
+    # Calculate step size of one sample, to offset ranges, as needed
+    offset = (1/n_samples * 2*np.pi)
+
+    # Create phase defintion for cycle with both extrema being asymmetric
     if side == 'both':
 
-        n_decay = n_samples - n_rise
+        phase = np.hstack([np.linspace(0, np.pi/2, n_rise_start),
+                           np.linspace(np.pi/2 + offset, -np.pi/2, n_decay_full),
+                           np.linspace(-np.pi/2 + offset, 0-offset, n_rise_end)])
 
-        # Make phase array for an asymmetric cycle
-        #   Note: the ceil & floor are so the cycle has the right number of samples if n_decay is odd
-        phase = np.hstack([np.linspace(0, np.pi/2, int(np.ceil(n_rise/2)) + 1),
-                           np.linspace(np.pi/2, -np.pi/2, n_decay + 1)[1:-1],
-                           np.linspace(-np.pi/2, 0, int(np.floor(n_rise/2)) + 1)[:-1]])
-
+    # Create phase defintion for cycle with only one extrema being asymmetric
     if side in ['peak', 'trough']:
 
-        half_sample = int(n_samples/2)
-
-        npts = int(np.ceil(n_rise/2)) + 1
-        offset = (1/half_sample * np.pi)
-
-        phase = np.hstack([np.linspace(0, np.pi/2, npts),
-                           np.linspace(np.pi/2, np.pi, half_sample-npts),
-                           np.linspace(np.pi + offset, 2*np.pi, half_sample + 1)[:-1]])
+        phase = np.hstack([np.linspace(0, np.pi/2, n_rise_start),
+                           np.linspace(np.pi/2, np.pi, n_decay_half),
+                           np.linspace(np.pi + offset, 2*np.pi-offset, half_sample)])
 
     # Convert phase definition to signal
     cycle = np.sin(phase)
 
+    # For asymmetric trough, rotate and flip the generated cycle
     if side == 'trough':
         cycle = -1 * phase_shift_cycle(cycle, 0.5)
 

--- a/neurodsp/tests/sim/test_cycles.py
+++ b/neurodsp/tests/sim/test_cycles.py
@@ -47,8 +47,9 @@ def test_sim_sine_cycle():
 
 def test_sim_asine_cycle():
 
-    cycle = sim_asine_cycle(N_SECONDS, FS, 0.25)
-    check_sim_output(cycle)
+    for side in ['both', 'peak', 'trough']:
+        cycle = sim_asine_cycle(N_SECONDS, FS, 0.25, side=side)
+        check_sim_output(cycle)
 
 def test_sim_sawtooth_cycle():
 


### PR DESCRIPTION
This update adds support for creating an asymmetric cycle with only one asymmetric extrema, to `sim_asine_cycle`.

For example, this code:
```
import matplotlib.pyplot as plt
from neurodsp.sim.cycles import sim_asine_cycle

fs, freq = 1000, 10
cycle = sim_asine_cycle(1/freq, fs, 0.25, 'peak')

plt.plot(cycle)
```

Would now work, to have a 'peak-only asymmetric cycle', and gives this:
<img width="390" alt="Screen Shot 2021-03-01 at 8 42 46 AM" src="https://user-images.githubusercontent.com/7727566/109505019-2de47100-7a6a-11eb-9dfc-81ae2869882d.png">

As a limitation of this - it seems unideal that there is an abrupt shift from the asymmetric to symmetric regime at the zero crossing point (ideally this might be smoother), but broadly I think this should be _okay_, and this update can still be useful for some things. 

Edit: I've been playing around with those code for awhile, including poking at different ways to do the offsets, and if there's a way to refactor what looks to be duplicated code. At this point, I _think_ it's probably easiest to stick with it as is, but one way or another I'm moving this to review stage to get some more eyes on it!
