### PR TITLE
[BUG] - Fix bug in `sim_bursty_oscillation`

### DIFF
--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -68,7 +68,7 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
     return sig
 
 
-def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params={},
+def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params=None,
                            cycle='sine', phase=0, **cycle_params):
     """Simulate a bursty oscillation.
 
@@ -147,6 +147,7 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params={
 
     # Consistency fix: catch old parameters, and remap into burst_params
     #   This preserves the prior default values, and makes the old API work the same
+    burst_params = {} if not burst_params else burst_params
     for burst_param in ['enter_burst', 'leave_burst']:
         temp = cycle_params.pop(burst_param, 0.2)
         if burst_def == 'prob' and burst_param not in burst_params:


### PR DESCRIPTION
There was a bug in `sim_bursty_oscillation`, due to defining an empty dictionary in the function definition, which turns out to be quite bad (ooops, my bad). Because we dynamically update the dictionary in the function, this updates the default value, leading to issues. 

Here's an isolated example of the issue:
```
def test_dict_issue(var={}):
    if not var:
        var['new'] = 'value'
        
print(test_dict_issue.__defaults__)
test_dict_issue()
print(test_dict_issue.__defaults__)
```
Which gives this output
```
({},)
({'new': 'value'},)
```

Basically, giving an empty dictionary as default, and then updating this object updates the object linked in the function definition. Once I tracked this down - it's a simple fix, but it's a bit of a funky bug. 

Anyways, interesting / weird Python quick. I sorta knew defaulting like this was bad, but now I actually get it - so lesson learned!