### PR TITLE
[ENH] - Update default for savefig

### DIFF
--- a/neurodsp/plts/utils.py
+++ b/neurodsp/plts/utils.py
@@ -34,9 +34,13 @@ def savefig(func):
     @wraps(func)
     def decorated(*args, **kwargs):
 
-        save_fig = kwargs.pop('save_fig', False)
+        # Grab file name and path arguments, if they are in kwargs
         file_name = kwargs.pop('file_name', None)
         file_path = kwargs.pop('file_path', None)
+
+        # Check for an explicit argument for whether to save figure or not
+        #   Defaults to saving when file name given (since bool(str)->True; bool(None)->False)
+        save_fig = kwargs.pop('save_fig', bool(file_name))
 
         func(*args, **kwargs)
 

--- a/neurodsp/tests/plts/test_utils.py
+++ b/neurodsp/tests/plts/test_utils.py
@@ -1,7 +1,8 @@
 """Tests for neurodsp.plts.utils."""
 
 import os
-import tempfile
+
+from neurodsp.tests.settings import TEST_PLOTS_PATH
 
 from neurodsp.plts.utils import *
 
@@ -30,6 +31,14 @@ def test_savefig():
     def example_plot():
         plt.plot([1, 2], [3, 4])
 
-    with tempfile.NamedTemporaryFile(mode='w+') as file:
-        example_plot(save_fig=True, file_name=file.name)
-        assert os.path.exists(file.name)
+    # Test defaults to saving given file path & name
+    example_plot(file_path=TEST_PLOTS_PATH, file_name='test_savefig1.pdf')
+    assert os.path.exists(os.path.join(TEST_PLOTS_PATH, 'test_savefig1.pdf'))
+
+    # Test works the same when explicitly given `save_fig`
+    example_plot(save_fig=True, file_path=TEST_PLOTS_PATH, file_name='test_savefig2.pdf')
+    assert os.path.exists(os.path.join(TEST_PLOTS_PATH, 'test_savefig2.pdf'))
+
+    # Test does not save when `save_fig` set to False
+    example_plot(save_fig=False, file_path=TEST_PLOTS_PATH, file_name='test_savefig3.pdf')
+    assert not os.path.exists(os.path.join(TEST_PLOTS_PATH, 'test_savefig3.pdf'))


### PR DESCRIPTION
This updates the `savefig` decorator to default to saving a figure when a file name is given, meaning `save_fig` does not have to be explicitly passed. The `save_fig` input can still be explicitly passed to stop the figure from saving. 

Following this update, this will now save:
`example_plot(file_path=TEST_PLOTS_PATH, file_name='test_savefig1.pdf')`

This will now not save:
`example_plot(save_fig=False, file_path=TEST_PLOTS_PATH, file_name='test_savefig3.pdf')`
^This might seem like a slightly weird construct, but it's something I use a fair amount - to define the name I need, but use a general setting to define when I actually save things.

This PR also updates the tests, generalizing them to check this new behaviour. It also moves away from using tempfile for these particular files, since that doesn't work well in this case (since the tempfiles are defined, the path check passes whether or not the figure file is saved). 