### PR TITLE
[MRG] Add multidim decorator to filter_signal

### DIFF
--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -2,12 +2,14 @@
 
 from warnings import warn
 
+from neurodsp.utils.decorators import multidim
 from neurodsp.filt.fir import filter_signal_fir
 from neurodsp.filt.iir import filter_signal_iir
 
 ###################################################################################################
 ###################################################################################################
 
+@multidim()
 def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
                   n_cycles=3, n_seconds=None, remove_edges=True, butterworth_order=None,
                   print_transitions=False, plot_properties=False, return_filter=False):

--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -2,14 +2,12 @@
 
 from warnings import warn
 
-from neurodsp.utils.decorators import multidim
 from neurodsp.filt.fir import filter_signal_fir
 from neurodsp.filt.iir import filter_signal_iir
 
 ###################################################################################################
 ###################################################################################################
 
-@multidim()
 def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
                   n_cycles=3, n_seconds=None, remove_edges=True, butterworth_order=None,
                   print_transitions=False, plot_properties=False, return_filter=False):
@@ -17,7 +15,7 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type='fir',
 
     Parameters
     ----------
-    sig : 1d array
+    sig : 1d or 2d array
         Time series to be filtered.
     fs : float
         Sampling rate, in Hz.

--- a/neurodsp/tests/filt/test_filter.py
+++ b/neurodsp/tests/filt/test_filter.py
@@ -2,6 +2,8 @@
 
 from pytest import raises, warns
 
+import numpy as np
+
 from neurodsp.tests.settings import FS, F_RANGE
 
 from neurodsp.filt.filter import *
@@ -20,6 +22,11 @@ def test_filter_signal(tsig):
 
     with raises(ValueError):
         out = filter_signal(tsig, FS, 'bandpass', F_RANGE, filter_type='bad')
+
+    # 2d check
+    sigs = np.array([tsig, tsig])
+    outs = filter_signal(sigs, FS, 'bandpass', F_RANGE, remove_edges=False)
+    assert np.diff(outs, axis=0).sum() == 0
 
 def test_iir_checks():
 

--- a/neurodsp/utils/decorators.py
+++ b/neurodsp/utils/decorators.py
@@ -69,7 +69,7 @@ def multidim(select=[]):
                     out = [data[0] if ind in select else data for ind, data in enumerate(out)]
 
                 else:
-                    out = np.stack(outs)
+                    out = np.array(outs)
 
             return out
 


### PR DESCRIPTION
This allows 2d signals to be passed to filter_signal. My use case was filtering a 2d array of signals from a MEA.

I also updated np.stack to np.array in the decorator since it's equivalent in this case and 10x faster.
```python
%%timeit
out = [i+j for i in range(1000) for j in range(1000)]
out = np.stack(out)
```
> 1.27 s ± 10.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```python
%%timeit
out = [i+j for i in range(1000) for j in range(1000)]
out = np.array(out)
```
> 98.9 ms ± 304 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)