### PR TITLE
[FIX] Error for invalid transition bandwidth

### DIFF
--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -179,7 +179,7 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
     inds = np.where(np.diff(np.logical_and(db > low, db < high)))[0]
 
     if len(inds) == 0:
-        transition_band = 0
+        raise ValueError("Invalid transition band. Redefine f_range.")
     else:
         # This steps through the indices, in pairs, selecting from the vector to select from
         transition_band = np.max([(b - a) for a, b in zip(f_db[inds[0::2]], f_db[inds[1::2]])])

--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -177,8 +177,12 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
 
     # This gets the indices of transitions to the values in searched for range
     inds = np.where(np.diff(np.logical_and(db > low, db < high)))[0]
-    # This steps through the indices, in pairs, selecting from the vector to select from
-    transition_band = np.max([(b - a) for a, b in zip(f_db[inds[0::2]], f_db[inds[1::2]])])
+
+    if len(inds) == 0:
+        transition_band = 0
+    else:
+        # This steps through the indices, in pairs, selecting from the vector to select from
+        transition_band = np.max([(b - a) for a, b in zip(f_db[inds[0::2]], f_db[inds[1::2]])])
 
     return transition_band
 


### PR DESCRIPTION
Addresses #266. This is based on 
```python
inds = np.where(np.diff(np.logical_and(db > low, db < high)))[0]
```
returning an empty array. ~~I assumed when this is the case the transition bandwidth should be zero.~~

This now raises a value error stating the transition band is invalid, and suggests to redefine f_range.