### PR TITLE
[ENH] Plot spectra accepts 2d arrays

### DIFF
--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -18,9 +18,9 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
 
     Parameters
     ----------
-    freqs : 1d or 2d array
+    freqs : 1d or 2d array or list of 1d array
         Frequency vector.
-    powers : 1d or 2d array
+    powers : 1d or 2d array or list of 1d array
         Power values.
     labels : str or list of str, optional
         Labels for each time series.

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -18,9 +18,9 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
 
     Parameters
     ----------
-    freqs : 1d array or list of 1d array
+    freqs : 1d or 2d array
         Frequency vector.
-    powers : 1d array or list of 1d array
+    powers : 1d or 2d array
         Power values.
     labels : str or list of str, optional
         Labels for each time series.
@@ -47,8 +47,7 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
 
     ax = check_ax(ax, (6, 6))
 
-    freqs = repeat(freqs) if isinstance(freqs, np.ndarray) else freqs
-    powers = [powers] if isinstance(powers, np.ndarray) else powers
+    freqs = repeat(freqs) if isinstance(freqs, np.ndarray) and freqs.ndim == 1 else freqs
 
     if labels is not None:
         labels = [labels] if not isinstance(labels, list) else labels

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -48,6 +48,7 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
     ax = check_ax(ax, (6, 6))
 
     freqs = repeat(freqs) if isinstance(freqs, np.ndarray) and freqs.ndim == 1 else freqs
+    powers = [powers] if isinstance(powers, np.ndarray) and powers.ndim == 1 else powers
 
     if labels is not None:
         labels = [labels] if not isinstance(labels, list) else labels


### PR DESCRIPTION
Before, `plot_power_spectra` only accepted 1d array or list of 1d array for freqs and powers. This adds support for 2d arrays. The requirement  to call `.tolist()` on a 2d power array for plotting to work felt strange - espcially since compute_spectrum returns 2d arrays for 2d inputs.

```python
import numpy as np
from neurodsp.sim import sim_oscillation
from neurodsp.spectral import compute_spectrum
from neurodsp.plts import plot_power_spectra

n_seconds = 10
fs = 1000
freqs = [10, 20]

# Simulate 2d array
sigs = np.zeros((2, n_seconds * fs))

for ind, freq in enumerate(freqs):
    sigs[ind] = sim_oscillation(n_seconds, fs, freq)

freqs, powers = compute_spectrum(sigs, fs)

# Freqs: list of 1d array
plot_power_spectra([freqs, freqs], powers)

# Freqs: 2d array
plot_power_spectra(np.array([freqs, freqs]), powers)

# Powers: list of 1d array
plot_power_spectra(freqs, [powers[0], powers[1]])

# Powers: 2d array
plot_power_spectra(freqs, powers)
```