### PR TITLE
[ENH] Allow min_n_cycles to be zero

### DIFF
--- a/neurodsp/burst/dualthresh.py
+++ b/neurodsp/burst/dualthresh.py
@@ -79,7 +79,7 @@ def detect_bursts_dual_threshold(sig, fs, dual_thresh, f_range=None,
 
     # Remove bursts detected that are too short
     # Use a number of cycles defined on the frequency range, if available
-    if f_range and min_n_cycles:
+    if f_range is not None and min_n_cycles is not None:
         min_burst_samples = int(np.ceil(min_n_cycles * fs / f_range[0]))
     # Otherwise, make sure minimum duration is set, and use that
     else:


### PR DESCRIPTION
This is a small update that allow `min_n_cycles = 0` to be passed to detect_bursts_dual_threshold -  in case one doesn't want to remove detected bursts based on duration. Before this would raise an error.