### PR TITLE
[BUG] - Fix bug in `sim_bursty_oscillation`

### DIFF
--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -348,7 +348,11 @@ def make_bursts(n_seconds, fs, is_oscillating, cycle):
 
     burst_sig = np.zeros([n_samples])
     for sig_ind, is_osc in zip(range(0, n_samples, n_samples_cycle), is_oscillating):
-        if is_osc:
+
+        # If set as an oscillating cycle, add cycle to signal
+        #   The sample check is to check there are enough samples left to add a full cycle
+        #   If there are not, this skipps the add, leaving zeros instead of adding part of a cycle
+        if is_osc and sig_ind + n_samples_cycle < n_samples:
             burst_sig[sig_ind:sig_ind+n_samples_cycle] = cycle
 
     return burst_sig

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -106,6 +106,14 @@ def test_make_bursts():
     sig = make_bursts(N_SECONDS, FS, is_osc, cycle)
     check_sim_output(sig)
 
+    # Test make bursts with uneven division of signal and cycle divisions
+    #   In this test, there aren't enough samples in the signal to add last cycle
+    is_osc = np.array([False, True, True])
+    cycle = np.ones([7])
+
+    sig = make_bursts(2, 10, is_osc, cycle)
+    assert sum(sig) > 0
+
 def test_make_is_osc_prob():
 
     is_osc = make_is_osc_prob(15, 0.5, 0.5)


### PR DESCRIPTION
Addresses #271 - details of the problem explained there. 

Basically, because the issue here is trying to add a cycle with a length greater than the remainder of the cycle, the proposed fix here is to skip the add if there are not enough samples enough for the cycle. This means whenever this context arises, regardless of the value of `is_oscillating`, the last few samples will be non-oscillating. 

There is an alternative: instead of leaving trailing zeros, we could update to add a truncated cycle with whatever samples are left. I see no strong reason to prefer one approach over the over, so I think the trailing zeros might be easier. 

For the record: the reason the this bug popped up now is we used to concatenate cycles and then trim the whole signal to the expected n_samples, whereas now (somewhere in the refactors) we pre-allocate exactly the length of the signal from the start (this does mean that with this PR what we do in this scenario is now a bit different from what we used to do). 

The new test explicitly tests the situation that would cause the issue (a cycle set to be added at the last cycle position, without enough samples left the add it). Note that this test would fail on the code in `main`. 

Anyways - long story short, unless anyone has strong thoughts on the strategy taken here, this should be a quick fix that is ready to merge. 