### PR TITLE
[BUG] - Fix doctest typo

### DIFF
--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -306,7 +306,7 @@ def sim_damped_oscillation(n_seconds, fs, freq, gamma, growth=None):
 
     Examples
     --------
-    >>> sig = sim_dampened_oscillation(1, 1000, 10, .1)
+    >>> sig = sim_damped_oscillation(1, 1000, 10, .1)
     """
 
     times = create_times(n_seconds, fs)


### PR DESCRIPTION
This fixes a small typo in the doctest, such that it would fail execution.

As a sidenote: one day we might poke at github actions, to get it to run doctests as well. 