### PR TITLE
[FIX] Sim knee update

### DIFF
--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -174,7 +174,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
 
     # Map the frequencies under the (square root) Lorentzian
     #   This will give us the amplitude coefficients for the sinusoids
-    cosine_coeffs = np.array([np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + knee))) \
+    cosine_coeffs = np.array([np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + (knee ** 2))))\
         for freq in freqs])
 
     # Add sinusoids with a random phase shift


### PR DESCRIPTION
I have been exploring different ways to simulate timescales and remembered we have a `sim_knee` function. After re-exploring this func, I noticed the knee frequency parameter passed into the function does not translate to the simulated knee location. I've update the coefficient equation so the knee is in the proper location.

Below is an example pre/post this PR, simulating a knee at 100hz with a exponent of 2:
![sim_knee](https://user-images.githubusercontent.com/34786005/142705550-1896c337-051e-4f89-ab8c-d769ce3e7c16.png)

Converting the model exponent and knee value to knee frequency, the knee frequency goes from ~10Hz to ~100Hz. However, the exponent becomes less accurate (2.00 -> 1.96).