### PR TITLE
[MNT] - Simulations refactors

### DIFF
--- a/neurodsp/aperiodic/dfa.py
+++ b/neurodsp/aperiodic/dfa.py
@@ -40,7 +40,7 @@ def compute_fluctuations(sig, fs, n_scales=10, min_scale=0.01, max_scale=1.0, de
         Time-scales over which fluctuation measures were computed.
     fluctuations : 1d array
         Average fluctuation at each scale.
-    exp : float
+    result : float
         Slope of line in log-log when plotting time scales against fluctuations.
         This is the alpha value for DFA, or the Hurst exponent for rescaled range.
 
@@ -83,9 +83,9 @@ def compute_fluctuations(sig, fs, n_scales=10, min_scale=0.01, max_scale=1.0, de
             fluctuations[idx] = compute_rescaled_range(sig, win_len=win_len)
 
     # Calculate the relationship between between fluctuations & time scales
-    exp = np.polyfit(np.log10(t_scales), np.log10(fluctuations), deg=1)[0]
+    result = np.polyfit(np.log10(t_scales), np.log10(fluctuations), deg=1)[0]
 
-    return t_scales, fluctuations, exp
+    return t_scales, fluctuations, result
 
 
 def compute_rescaled_range(sig, win_len):

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -142,6 +142,7 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
         Power law exponent after the knee.
     knee : float
         Location of the knee in Hz.
+
     Returns
     -------
     sig : 1d array

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -141,7 +141,7 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
     exponent2 : float
         Power law exponent after the knee.
     knee : float
-        Location of the knee in Hz.
+        Knee parameter.
 
     Returns
     -------
@@ -179,9 +179,7 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
 
     for f in freqs:
 
-        knee_term = knee**(-2*exponent1 - exponent2)
-
-        sig += np.sqrt(1 / (f ** -exponent1 * (f ** (-exponent2 - exponent1) + knee_term))) * \
+        sig += np.sqrt(1 / (f ** -exponent1 * (f ** (-exponent2 - exponent1) + knee))) * \
             np.cos(2 * np.pi * f * times + 2 * np.pi * np.random.rand())
 
     return sig

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -179,7 +179,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     # Define & vectorize function for computing the set of sinusoids, adding a random phase shift
     def _create_sines(freq):
         return coscoef(freq) * np.cos(2 * np.pi * freq * times + 2 * np.pi * np.random.rand())
-    vect_create_sines = np.vectorize(_create_sines, signature='() -> (n)')
+    vect_create_sines = np.vectorize(_create_sines, signature='()->(n)')
 
     # Create the set of sinusoids across the set of frequencies
     sines = vect_create_sines(freqs)

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -152,11 +152,12 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
     -----
     This simulated time series has a power spectrum that follows the Lorentzian equation:
 
-    `P(f) = 1 / (f**exponent1 * (f**exponent2 + knee))`
+    `P(f) = 1 / (f**(exponent1) * f**(exponent2 + exponent1) + knee)`
 
     - This simulation creates this power spectrum shape using a sum of sinusoids.
-    - The slope of the log power spectrum before the knee is exponent1 whereas after the knee
-    it is exponent2, but only when the sign of exponent1 and exponent2 are the same.
+    - The slope of the log power spectrum before the knee is exponent1
+    - The slope after the knee is exponent2, but only when the sign of
+      exponent1 and exponent2 are the same.
 
     Examples
     --------

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -173,21 +173,12 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
     freqs = np.linspace(0, fs / 2, num=int(n_samples // 2 + 1), endpoint=True)
     freqs = freqs[1:]
 
-    # Define sub-function for computing the amplitude coefficients for the cosines
-    #   This computes the square root of the Lorentzian
-    def _coscoef(freq):
-        return np.sqrt(1 / (freq ** -exponent1 * (freq ** (-exponent2 - exponent1) + knee)))
+    # Compute cosine amplitude coefficients and add a random phase shift
+    sig = np.zeros(n_samples)
 
-    # Define & vectorize sub-function for computing the set of cosines, adding a random phase shift
-    def _create_cosines(freq):
-        return _coscoef(freq) * np.cos(2 * np.pi * freq * times + 2 * np.pi * np.random.rand())
-    vect_create_cosines = np.vectorize(_create_cosines, signature='()->(n)')
-
-    # Create the set of cosines
-    cosines = vect_create_cosines(freqs)
-
-    # Create the final signal by summing the cosines
-    sig = np.sum(cosines, axis=0)
+    for f in freqs:
+        sig += np.sqrt(1 / (f ** -exponent1 * (f ** (-exponent2 - exponent1) + knee))) \
+            * np.cos(2 * np.pi * f * times + 2 * np.pi * np.random.rand())
 
     return sig
 

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -173,12 +173,14 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     freqs = np.linspace(0, fs / 2, num=int(n_samples // 2 + 1), endpoint=True)
     freqs = freqs[1:]
 
-    # Lambda for computing the amplitude coefficients for the sinusoids (square root Lorentzian)
-    coscoef = lambda freq : np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + knee)))
+    # Define sub-function for computing the amplitude coefficients for the sinusoids
+    #   This computes the square root of the Lorentzian
+    def _coscoef(freq):
+        return np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + knee)))
 
-    # Define & vectorize function for computing the set of sinusoids, adding a random phase shift
+    # Define & vectorize sub-function for computing the set of sinusoids, adding a random phase shift
     def _create_sines(freq):
-        return coscoef(freq) * np.cos(2 * np.pi * freq * times + 2 * np.pi * np.random.rand())
+        return _coscoef(freq) * np.cos(2 * np.pi * freq * times + 2 * np.pi * np.random.rand())
     vect_create_sines = np.vectorize(_create_sines, signature='()->(n)')
 
     # Create the set of sinusoids across the set of frequencies

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -142,7 +142,6 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
         Power law exponent after the knee.
     knee : float
         Location of the knee in Hz.
-
     Returns
     -------
     sig : 1d array
@@ -177,8 +176,11 @@ def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
     sig = np.zeros(n_samples)
 
     for f in freqs:
-        sig += np.sqrt(1 / (f ** -exponent1 * (f ** (-exponent2 - exponent1) + knee))) \
-            * np.cos(2 * np.pi * f * times + 2 * np.pi * np.random.rand())
+
+        knee_term = knee**(-2*exponent1 - exponent2)
+
+        sig += np.sqrt(1 / (f ** -exponent1 * (f ** (-exponent2 - exponent1) + knee_term))) * \
+            np.cos(2 * np.pi * f * times + 2 * np.pi * np.random.rand())
 
     return sig
 

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -127,7 +127,7 @@ def sim_synaptic_current(n_seconds, fs, n_neurons=1000, firing_rate=2.,
 
 
 @normalize
-def sim_knee(n_seconds, fs, chi1, chi2, knee):
+def sim_knee(n_seconds, fs, exponent1, exponent2, knee):
     """Simulate a signal whose power spectrum has a 1/f structure with a knee.
 
     Parameters
@@ -136,10 +136,10 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
         Simulation time, in seconds.
     fs : float
         Sampling rate of simulated signal, in Hz.
-    chi1 : float
+    exponent1 : float
         Power law exponent before the knee.
-    chi2 : float
-        Power law exponent added to chi1 after the knee.
+    exponent2 : float
+        Power law exponent after the knee.
     knee : float
         Location of the knee in Hz.
 
@@ -152,17 +152,17 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     -----
     This simulated time series has a power spectrum that follows the Lorentzian equation:
 
-    `P(f) = 1 / (f**chi1 * (f**chi2 + knee))`
+    `P(f) = 1 / (f**exponent1 * (f**exponent2 + knee))`
 
     - This simulation creates this power spectrum shape using a sum of sinusoids.
-    - The slope of the log power spectrum before the knee is chi1 whereas after the knee it is chi2,
-    but only when the sign of chi1 and chi2 are the same.
+    - The slope of the log power spectrum before the knee is exponent1 whereas after the knee
+    it is exponent2, but only when the sign of exponent1 and exponent2 are the same.
 
     Examples
     --------
-    Simulate a time series with chi1 of -1, chi2 of -2, and knee of 100:
+    Simulate a time series with exponent1 of -1, exponent2 of -2, and knee of 100:
 
-    >> sim_knee(n_seconds=10, fs=1000, chi1=-1, chi2=-2, knee=100)
+    >> sim_knee(n_seconds=10, fs=1000, exponent1=-1, exponent2=-2, knee=100)
     """
 
     times = create_times(n_seconds, fs)
@@ -176,7 +176,7 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     # Define sub-function for computing the amplitude coefficients for the cosines
     #   This computes the square root of the Lorentzian
     def _coscoef(freq):
-        return np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + knee)))
+        return np.sqrt(1 / (freq ** -exponent1 * (freq ** (-exponent2 - exponent1) + knee)))
 
     # Define & vectorize sub-function for computing the set of cosines, adding a random phase shift
     def _create_cosines(freq):
@@ -325,7 +325,7 @@ def sim_powerlaw(n_seconds, fs, exponent=-2.0, f_range=None, **filter_kwargs):
 
 
 @normalize
-def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
+def sim_frac_gaussian_noise(n_seconds, fs, exponent=0, hurst=None):
     """Simulate a timeseries as fractional gaussian noise.
 
     Parameters
@@ -334,12 +334,12 @@ def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
         Simulation time, in seconds.
     fs : float
         Sampling rate of simulated signal, in Hz.
-    chi: float, optional, default: 0
+    exponent : float, optional, default: 0
         Desired power law exponent of the spectrum of the signal.
         Must be in the range (-1, 1).
     hurst : float, optional, default: None
         Desired Hurst parameter, which must be in the range (0, 1).
-        If provided, this value overwrites the `chi` parameter.
+        If provided, this value overwrites the `exponent` parameter.
 
     Returns
     -------
@@ -355,8 +355,8 @@ def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
     The Hurst parameter is defined for self-similar processes such that Y(at) = a^H Y(t)
     for all a > 0, where this equality holds in distribution.
 
-    The relationship between the power law exponent chi and the Hurst parameter
-    for fractional gaussian noise is chi = 2 * hurst - 1.
+    The relationship between the power law exponent and the Hurst parameter
+    for fractional gaussian noise is exponent = 2 * hurst - 1.
 
     For more information, consult [1]_.
 
@@ -370,7 +370,7 @@ def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
     --------
     Simulate fractional gaussian noise with a power law decay of 0 (white noise):
 
-    >>> sig = sim_frac_gaussian_noise(n_seconds=1, fs=500, chi=0)
+    >>> sig = sim_frac_gaussian_noise(n_seconds=1, fs=500, exponent=0)
 
     Simulate fractional gaussian noise with a Hurst parameter of 0.5 (also white noise):
 
@@ -381,10 +381,10 @@ def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
         check_param_range(hurst, 'hurst', (0, 1))
 
     else:
-        check_param_range(chi, 'chi', (-1, 1))
+        check_param_range(exponent, 'exponent', (-1, 1))
 
-        # Infer the hurst parameter from chi
-        hurst = (-chi + 1.) / 2
+        # Infer the hurst parameter from exponent
+        hurst = (-exponent + 1.) / 2
 
     # Compute the number of samples for the simulated time series
     n_samples = compute_nsamples(n_seconds, fs)
@@ -408,7 +408,7 @@ def sim_frac_gaussian_noise(n_seconds, fs, chi=0, hurst=None):
 
 
 @normalize
-def sim_frac_brownian_motion(n_seconds, fs, chi=-2, hurst=None):
+def sim_frac_brownian_motion(n_seconds, fs, exponent=-2, hurst=None):
     """Simulate a timeseries as fractional brownian motion.
 
     Parameters
@@ -417,12 +417,12 @@ def sim_frac_brownian_motion(n_seconds, fs, chi=-2, hurst=None):
         Simulation time, in seconds.
     fs : float
         Sampling rate of simulated signal, in Hz.
-    chi : float, optional, default: -2
+    exponent : float, optional, default: -2
         Desired power law exponent of the spectrum of the signal.
         Must be in the range (-3, -1).
     hurst : float, optional, default: None
         Desired Hurst parameter, which must be in the range (0, 1).
-        If provided, this value overwrites the `chi` parameter.
+        If provided, this value overwrites the `exponent` parameter.
 
     Returns
     -------
@@ -435,15 +435,15 @@ def sim_frac_brownian_motion(n_seconds, fs, chi=-2, hurst=None):
     or alternatively with a specified Hurst parameter.
 
     Note that when specifying there can be some bias leading to a steeper than expected
-    spectrum of the simulated signal. This bias is higher for chi values near to 1,
+    spectrum of the simulated signal. This bias is higher for exponent values near to 1,
     and may be more severe in shorter signals.
 
     The Hurst parameter is not the Hurst exponent in general. The Hurst parameter
     is defined for self-similar processes such that Y(at) = a^H Y(t) for all a > 0,
     where this equality holds in distribution.
 
-    The relationship between the power law exponent chi and the Hurst parameter
-    for fractional brownian motion is chi = 2 * hurst + 1
+    The relationship between the power law exponent and the Hurst parameter
+    for fractional brownian motion is exponent = 2 * hurst + 1
 
     For more information, consult [1]_ and/or [2]_.
 
@@ -458,7 +458,7 @@ def sim_frac_brownian_motion(n_seconds, fs, chi=-2, hurst=None):
     --------
     Simulate fractional brownian motion with a power law exponent of -2 (brown noise):
 
-    >>> sig = sim_frac_brownian_motion(n_seconds=1, fs=500, chi=-2)
+    >>> sig = sim_frac_brownian_motion(n_seconds=1, fs=500, exponent=-2)
 
     Simulate fractional brownian motion with a Hurst parameter of 0.5 (also brown noise):
 
@@ -469,10 +469,10 @@ def sim_frac_brownian_motion(n_seconds, fs, chi=-2, hurst=None):
         check_param_range(hurst, 'hurst', (0, 1))
 
     else:
-        check_param_range(chi, 'chi', (-3, -1))
+        check_param_range(exponent, 'exponent', (-3, -1))
 
-        # Infer the hurst parameter from chi
-        hurst = (-chi - 1.) / 2
+        # Infer the hurst parameter from exponent
+        hurst = (-exponent - 1.) / 2
 
     # Fractional brownian motion is the cumulative sum of fractional gaussian noise
     fgn = sim_frac_gaussian_noise(n_seconds, fs, hurst=hurst)

--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -168,26 +168,26 @@ def sim_knee(n_seconds, fs, chi1, chi2, knee):
     times = create_times(n_seconds, fs)
     n_samples = compute_nsamples(n_seconds, fs)
 
-    # Create frequencies for the power spectrum, and drop the DC component
+    # Create frequencies for the power spectrum and drop the DC component
     #   These frequencies are used to create the cosines to sum
     freqs = np.linspace(0, fs / 2, num=int(n_samples // 2 + 1), endpoint=True)
     freqs = freqs[1:]
 
-    # Define sub-function for computing the amplitude coefficients for the sinusoids
+    # Define sub-function for computing the amplitude coefficients for the cosines
     #   This computes the square root of the Lorentzian
     def _coscoef(freq):
         return np.sqrt(1 / (freq ** -chi1 * (freq ** (-chi2 - chi1) + knee)))
 
-    # Define & vectorize sub-function for computing the set of sinusoids, adding a random phase shift
-    def _create_sines(freq):
+    # Define & vectorize sub-function for computing the set of cosines, adding a random phase shift
+    def _create_cosines(freq):
         return _coscoef(freq) * np.cos(2 * np.pi * freq * times + 2 * np.pi * np.random.rand())
-    vect_create_sines = np.vectorize(_create_sines, signature='()->(n)')
+    vect_create_cosines = np.vectorize(_create_cosines, signature='()->(n)')
 
-    # Create the set of sinusoids across the set of frequencies
-    sines = vect_create_sines(freqs)
+    # Create the set of cosines
+    cosines = vect_create_cosines(freqs)
 
-    # Create the final signal by summing across all sinusoids
-    sig = np.sum(sines, axis=0)
+    # Create the final signal by summing the cosines
+    sig = np.sum(cosines, axis=0)
 
     return sig
 

--- a/neurodsp/tests/aperiodic/test_dfa.py
+++ b/neurodsp/tests/aperiodic/test_dfa.py
@@ -15,16 +15,16 @@ from neurodsp.aperiodic.dfa import *
 
 def test_compute_fluctuations(tsig):
 
-    t_scales, flucs, exp = compute_fluctuations(tsig, 500)
+    t_scales, flucs, result = compute_fluctuations(tsig, 500)
     assert len(t_scales) == len(flucs)
 
     # Check error if the settings create window lengths that are too short
     with raises(ValueError):
-        t_scales, flucs, exp = compute_fluctuations(tsig, 100)
+        t_scales, flucs, result = compute_fluctuations(tsig, 100)
 
     # Check error for nonsense method input
     with raises(ValueError):
-        t_scales, flucs, exp = compute_fluctuations(tsig, 500, method='nope.')
+        t_scales, flucs, result = compute_fluctuations(tsig, 500, method='nope.')
 
 def test_compute_fluctuations_dfa():
 
@@ -33,13 +33,13 @@ def test_compute_fluctuations_dfa():
     # Test white noise: expected DFA of 0.5
     fs = 1000
     white = sim_powerlaw(N_SECONDS, fs, exponent=0)
-    t_scales, flucs, exp = compute_fluctuations(white, fs, method='dfa')
-    assert np.isclose(exp, 0.5, atol=0.1)
+    t_scales, flucs, alpha = compute_fluctuations(white, fs, method='dfa')
+    assert np.isclose(alpha, 0.5, atol=0.1)
 
     # Test brown noise: expected DFA of 1.5
     brown = sim_powerlaw(N_SECONDS, fs, exponent=-2)
-    t_scales, flucs, exp = compute_fluctuations(brown, fs, method='dfa')
-    assert np.isclose(exp, 1.5, atol=0.1)
+    t_scales, flucs, alpha = compute_fluctuations(brown, fs, method='dfa')
+    assert np.isclose(alpha, 1.5, atol=0.1)
 
 def test_compute_fluctuations_rs():
 
@@ -48,8 +48,8 @@ def test_compute_fluctuations_rs():
     # Test white noise: expected RS of 0.5
     fs = 1000
     white = sim_powerlaw(N_SECONDS, fs, exponent=0)
-    t_scales, flucs, exp = compute_fluctuations(white, fs, method='rs')
-    assert np.isclose(exp, 0.5, atol=0.1)
+    t_scales, flucs, hurst = compute_fluctuations(white, fs, method='rs')
+    assert np.isclose(hurst, 0.5, atol=0.1)
 
 def test_compute_rescaled_range(tsig):
 

--- a/neurodsp/tests/settings.py
+++ b/neurodsp/tests/settings.py
@@ -25,7 +25,7 @@ FREQS_LST = [8, 12, 1]
 FREQS_ARR = np.array([5, 10, 15])
 EXP1 = -1
 EXP2 = -2
-KNEE = 10
+KNEE = 100
 
 # Define settings for testing analyses
 F_RANGE = (FREQ1-2, FREQ1+2)

--- a/neurodsp/tests/settings.py
+++ b/neurodsp/tests/settings.py
@@ -25,7 +25,7 @@ FREQS_LST = [8, 12, 1]
 FREQS_ARR = np.array([5, 10, 15])
 EXP1 = -1
 EXP2 = -2
-KNEE = 10**2
+KNEE = 10
 
 # Define settings for testing analyses
 F_RANGE = (FREQ1-2, FREQ1+2)

--- a/neurodsp/tests/sim/test_aperiodic.py
+++ b/neurodsp/tests/sim/test_aperiodic.py
@@ -47,7 +47,7 @@ def test_sim_knee():
     np.allclose(true_psd, numerical_psd, atol=EPS)
 
     # Accuracy test for a single exponent
-    sig = sim_knee(n_seconds=N_SECONDS, fs=FS, chi1=0, chi2=EXP2, knee=KNEE)
+    sig = sim_knee(N_SECONDS, FS, 0, EXP2, KNEE)
 
     freqs, powers = compute_spectrum(sig, FS, f_range=(1, 200))
 
@@ -73,31 +73,31 @@ def test_sim_powerlaw():
     sig = sim_powerlaw(N_SECONDS, FS, f_range=(2, None))
     check_sim_output(sig)
 
-@pytest.mark.parametrize('chi', [-.5, 0, .5])
-def test_sim_frac_gaussian_noise(chi):
+@pytest.mark.parametrize('exponent', [-.5, 0, .5])
+def test_sim_frac_gaussian_noise(exponent):
 
     # Simulate & check time series
-    sig = sim_frac_gaussian_noise(N_SECONDS, FS, chi=chi)
+    sig = sim_frac_gaussian_noise(N_SECONDS, FS, exponent=exponent)
     check_sim_output(sig)
 
     # Linear fit the log-log power spectrum & check error based on expected 1/f exponent
     freqs = np.linspace(1, FS//2, num=FS//2)
     powers = np.abs(np.fft.fft(sig)[1:FS//2 + 1]) ** 2
-    [_, chi_hat], _ = curve_fit(check_exponent, np.log10(freqs), np.log10(powers))
-    assert abs(chi_hat - chi) < 0.2
+    [_, exponent_hat], _ = curve_fit(check_exponent, np.log10(freqs), np.log10(powers))
+    assert abs(exponent_hat - exponent) < 0.2
 
-@pytest.mark.parametrize('chi', [-1.5, -2, -2.5])
-def test_sim_frac_brownian_motion(chi):
+@pytest.mark.parametrize('exponent', [-1.5, -2, -2.5])
+def test_sim_frac_brownian_motion(exponent):
 
     # Simulate & check time series
-    sig = sim_frac_brownian_motion(N_SECONDS, FS, chi=chi)
+    sig = sim_frac_brownian_motion(N_SECONDS, FS, exponent=exponent)
     check_sim_output(sig)
 
     # Linear fit the log-log power spectrum & check error based on expected 1/f exponent
     freqs = np.linspace(1, FS//2, num=FS//2)
     powers = np.abs(np.fft.fft(sig)[1:FS//2 + 1]) ** 2
-    [_, chi_hat], _ = curve_fit(check_exponent, np.log10(freqs), np.log10(powers))
-    assert abs(chi_hat - chi) < 0.4
+    [_, exponent_hat], _ = curve_fit(check_exponent, np.log10(freqs), np.log10(powers))
+    assert abs(exponent_hat - exponent) < 0.4
 
 def test_create_powerlaw():
 

--- a/neurodsp/tests/sim/test_aperiodic.py
+++ b/neurodsp/tests/sim/test_aperiodic.py
@@ -38,14 +38,13 @@ def test_sim_knee():
 
     # Ignore the DC component to avoid division by zero in the Lorentzian
     freqs = freqs[1:]
-    true_psd = 1 / ((freqs ** -EXP1 * (freqs ** (-EXP2 - EXP1)+ KNEE**(-2*EXP1 - EXP2))))
+    true_psd = 1 / ((freqs ** -EXP1 * (freqs ** (-EXP2 - EXP1)+ KNEE)))
 
     # Only look at the frequencies (ignoring DC component) up to the nyquist rate
     sig_hat = np.fft.fft(sig)[1:sig_len//2]
     numerical_psd = np.abs(sig_hat)**2
 
     scale = numerical_psd / true_psd
-
     np.allclose(true_psd*scale, numerical_psd, atol=EPS)
 
     # Accuracy test for a single exponent
@@ -54,7 +53,7 @@ def test_sim_knee():
     freqs, powers = compute_spectrum(sig, FS, f_range=(1, 200))
 
     def _estimate_single_knee(xs, offset, knee, exponent):
-        return np.zeros_like(xs) + offset - np.log10(xs**exponent + knee**exponent)
+        return np.zeros_like(xs) + offset - np.log10(xs**exponent + knee)
 
     ap_params, _ = curve_fit(_estimate_single_knee, freqs, np.log10(powers))
     _, KNEE_hat, EXP2_hat = ap_params[:]

--- a/neurodsp/tests/tutils.py
+++ b/neurodsp/tests/tutils.py
@@ -45,5 +45,5 @@ def plot_test(func):
 
     return wrapper
 
-def check_exponent(xs, offset, chi):
-    return xs*chi + offset
+def check_exponent(xs, offset, exp):
+    return xs*exp + offset


### PR DESCRIPTION
This PR does some refactors and tweaks of some of the newer simulation functions. 

### Naming

An open question (nothing changed yet) is if we want to do any naming updates. 
- In particular, across the module we use both `exponent` (or `exp`), and now in these newer functions, `chi` to refer to the aperiodic exponent. I think I would vote we consolidate on using the term `exponent` consistently for this. The main counterpoint I can think of is that `exponent` is a pretty generic name, and in some cases it could be a little unclear. 
- While we're on the topic, I'm not 100% sold on `sim_peak_oscillation`, which seems to imply a slightly different thing from this being a "combined"  signal. I'm not sure I have a better suggestion though...

Thoughts?

### Optimizations

For `sim_knee` and `sim_peak_oscillation`, there where a bunch of embedded loops that seemed optimizable - the updates here being to use sub-functions where they could be used and where appropriate, vectorize functions for applying across the vectors. Combining both also removed some interim computations of arrays. I also think the code might be a little clearer. 

Optimization updates:
- `sim_knee`: speedup of ~20-25% faster of shorter signals (10s), and ~100% faster for longer signals (60s)
- `sim_peak_oscillation`: speedup of ~20-25% faster of shorter signals (10s), and ~100% faster for longer signals (60s)

All the actually computations are the same code, and I validated that the new versions give the same results

@ryanhammonds - in terms of review, I'm fairly confident about the updates here, so they shouldn't need a wild amount of further testing for the code changes. Let me know if you have any thoughts on naming, and I'd also be curious to hear if you have any other optimization ideas. 