### PR TITLE
[ENH] - Add sim functions to creating amplitude modulated signals

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -386,6 +386,8 @@ Data
     create_freqs
     create_times
     create_samples
+    compute_nsamples
+    compute_nseconds
     split_signal
 
 Outliers

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -274,12 +274,13 @@ Transients & Cycles
 Combined Signals
 ~~~~~~~~~~~~~~~~
 
-.. currentmodule:: neurodsp.sim
+.. currentmodule:: neurodsp.sim.combined
 .. autosummary::
     :toctree: generated/
 
     sim_combined
     sim_peak_oscillation
+    sim_modulated_signal
 
 Utilities
 ~~~~~~~~~
@@ -290,6 +291,7 @@ Utilities
 
     rotate_spectrum
     rotate_timeseries
+    modulate_signal
 
 Random Seed
 ~~~~~~~~~~~

--- a/neurodsp/sim/__init__.py
+++ b/neurodsp/sim/__init__.py
@@ -8,4 +8,4 @@ from .aperiodic import (sim_powerlaw, sim_random_walk, sim_synaptic_current, sim
                         sim_knee, sim_frac_gaussian_noise, sim_frac_brownian_motion)
 from .cycles import sim_cycle
 from .transients import sim_synaptic_kernel, sim_action_potential
-from .combined import sim_combined, sim_peak_oscillation
+from .combined import sim_combined, sim_peak_oscillation, sim_modulated_signal

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.linalg import norm
 
 from neurodsp.sim.info import get_sim_func
+from neurodsp.sim.utils import modulate_signal
 from neurodsp.utils.decorators import normalize
 from neurodsp.utils.data import create_times
 
@@ -160,3 +161,56 @@ def sim_peak_oscillation(sig_ap, fs, freq, bw, height):
     sig = sig_ap + sig_periodic
 
     return sig
+
+
+def sim_modulated_signal(n_seconds, fs, sig_func, sig_params, mod_func, mod_params):
+    """Simulate an amplitude modulated signal.
+
+    Parameters
+    ----------
+    n_seconds : float
+        Simulation time, in seconds.
+    fs : float
+        Signal sampling rate, in Hz.
+    sig_func : str
+        Name of the function to use to simulate the signal.
+    sig_param : dictionary
+        Parameters for the signal generation function.
+    mod_func : callable
+        Name of the function to use to simulate the modulating signal.
+    mod_params : dictionary
+        Parameters for the modulation function.
+
+    Returns
+    -------
+    msig : 1d array
+        Amplitude modulated signal.
+
+    Notes
+    -----
+    String labels for `sig_func` & `mod_func` can be any sim function available in the module.
+
+    Examples
+    --------
+    Simulate an oscillatory signal that is amplitude modulated for a slower oscillation:
+
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> msig_osc = sim_modulated_signal(n_seconds, fs,
+    ...                                 'sim_oscillation', {'freq' : 10},
+    ...                                 'sim_oscillation', {'freq' : 1})
+
+    Simulate an oscillatory signal that is amplitude modulated by a 1/f drift:
+
+    >>> n_seconds = 10
+    >>> fs = 500
+    >>> msig_ap = sim_modulated_signal(n_seconds, fs,
+    ...                                'sim_oscillation', {'freq' : 10},
+    ...                                'sim_powerlaw', {'exponent' : -1})
+    """
+
+    sig = get_sim_func(sig_func)(n_seconds, fs, **sig_params)
+    mod = get_sim_func(mod_func)(n_seconds, fs, **mod_params)
+    msig = modulate_signal(sig, mod)
+
+    return msig

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -163,6 +163,7 @@ def sim_peak_oscillation(sig_ap, fs, freq, bw, height):
     return sig
 
 
+@normalize
 def sim_modulated_signal(n_seconds, fs, sig_func, sig_params, mod_func, mod_params):
     """Simulate an amplitude modulated signal.
 

--- a/neurodsp/sim/utils.py
+++ b/neurodsp/sim/utils.py
@@ -118,10 +118,10 @@ def modulate_signal(sig, modulation, fs=None, mod_params=None):
     ----------
     sig : 1d array
         A signal to modulate.
-    modulation : 1d array or callable
+    modulation : 1d array or str
         Modulation to apply to the signal.
         If array, the modulating signal to apply directly to the signal.
-        If callable, a function to simulate the modulating signal that will be applied.
+        If str, a function name to use to simulate the modulating signal that will be applied.
     fs : float, optional
         Signal sampling rate, in Hz.
         Only needed if `modulation` is a callable.
@@ -145,11 +145,11 @@ def modulate_signal(sig, modulation, fs=None, mod_params=None):
 
     Amplitude modulate a sinusoidal signal with precomputed 1/f signal:
 
-    >>> from neurodsp.sim import sim_oscillation
+    >>> from neurodsp.sim import sim_oscillation, sim_powerlaw
     >>> n_seconds = 10
     >>> fs = 500
     >>> sig = sim_oscillation(n_seconds, fs, freq=10)
-    >>> mod = sim_oscillation(n_seconds, fs, exponent=-1)
+    >>> mod = sim_powerlaw(n_seconds, fs, exponent=-1)
     >>> msig = modulate_signal(sig, mod)
     """
 
@@ -157,7 +157,8 @@ def modulate_signal(sig, modulation, fs=None, mod_params=None):
         mod_func = get_sim_func(modulation)
         modulation = mod_func(compute_nseconds(sig, fs), fs, **mod_params)
 
-    assert len(sig) == len(modulation), 'Lengths of the signal and modulator must match to apply modulation'
+    assert len(sig) == len(modulation), \
+        'Lengths of the signal and modulator must match to apply modulation'
 
     msig = sig * modulation
 

--- a/neurodsp/tests/sim/test_combined.py
+++ b/neurodsp/tests/sim/test_combined.py
@@ -44,3 +44,15 @@ def test_sim_peak_oscillation():
     _, powers = compute_spectrum(sig, FS)
 
     assert abs(np.argmax(powers-powers_ap) - FREQ1) < 5
+
+def test_sim_modulated_signal():
+
+    msig1 = sim_modulated_signal(N_SECONDS, FS,
+                                'sim_oscillation', {'freq' : 10},
+                                'sim_oscillation', {'freq' : 1})
+    check_sim_output(msig1)
+
+    msig2 = sim_modulated_signal(N_SECONDS, FS,
+                                 'sim_oscillation', {'freq' : 10},
+                                 'sim_powerlaw', {})
+    check_sim_output(msig2)

--- a/neurodsp/tests/sim/test_utils.py
+++ b/neurodsp/tests/sim/test_utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from neurodsp.tests.tutils import check_sim_output
 from neurodsp.tests.settings import FS
 
 from neurodsp.sim.utils import *
@@ -23,3 +24,13 @@ def test_rotate_spectrum():
 
     pows_new = rotate_spectrum(freqs, pows, d_exp)
     assert pows.shape == pows_new.shape
+
+def test_modulate_signal(tsig):
+
+    # Check modulation applied by specifying a function name
+    msig1 = modulate_signal(tsig, 'sim_oscillation', FS, {'freq' : 1})
+    check_sim_output(msig1)
+
+    # Check modulation passing in a 1d array directly
+    msig2 = modulate_signal(tsig, tsig)
+    check_sim_output(msig2)

--- a/neurodsp/tests/utils/test_data.py
+++ b/neurodsp/tests/utils/test_data.py
@@ -50,7 +50,7 @@ def test_compute_nsamples():
 
 def test_compute_nseconds(tsig):
 
-    n_seconds = compute_nseconds(sig, FS)
+    n_seconds = compute_nseconds(tsig, FS)
     assert isinstance(n_seconds, float)
     assert n_seconds == N_SECONDS
 

--- a/neurodsp/tests/utils/test_data.py
+++ b/neurodsp/tests/utils/test_data.py
@@ -48,6 +48,12 @@ def test_compute_nsamples():
     assert isinstance(n_samples, int)
     assert n_samples == int(np.ceil(N_SECONDS_ODD * FS_ODD))
 
+def test_compute_nseconds(tsig):
+
+    n_seconds = compute_nseconds(sig, FS)
+    assert isinstance(n_seconds, float)
+    assert n_seconds == N_SECONDS
+
 def test_split_signal(tsig):
 
     chunks = split_signal(tsig, 100)

--- a/neurodsp/utils/data.py
+++ b/neurodsp/utils/data.py
@@ -19,7 +19,7 @@ def create_freqs(freq_start, freq_stop, freq_step=1):
 
     Returns
     -------
-    1d array
+    freqs : 1d array
         Frequency indices.
     """
 
@@ -40,7 +40,7 @@ def create_times(n_seconds, fs, start_val=0.):
 
     Returns
     -------
-    1d array
+    times : 1d array
         Time indices.
     """
 
@@ -52,14 +52,14 @@ def create_samples(n_samples, start_val=0):
 
     Parameters
     ----------
-    n_seconds : int
+    n_seconds : float
         Signal duration, in seconds.
     start_val : int, optional, default: 0
         Starting value for the samples definition.
 
     Returns
     -------
-    1d array
+    samples : 1d array
         Sample indices.
     """
 
@@ -71,14 +71,14 @@ def compute_nsamples(n_seconds, fs):
 
     Parameters
     ----------
-    n_seconds : int
+    n_seconds : float
         Signal duration, in seconds.
     fs : float
         Signal sampling rate, in Hz.
 
     Returns
     -------
-    int
+    n_samples : int
         The number of samples.
 
     Notes
@@ -89,6 +89,25 @@ def compute_nsamples(n_seconds, fs):
     """
 
     return int(np.ceil(n_seconds * fs))
+
+
+def compute_nseconds(sig, fs):
+    """Compute the length, in time, of a signal.
+
+    Parameters
+    ----------
+    sig : 1d array
+        Time series.
+    fs : float
+        Signal sampling rate, in Hz.
+
+    Returns
+    -------
+    fs : float
+        Signal duration, in seconds.
+    """
+
+    return len(sig) / fs
 
 
 def split_signal(sig, n_samples):
@@ -103,7 +122,7 @@ def split_signal(sig, n_samples):
 
     Returns
     -------
-    segs : 2d array
+    segments : 2d array
         The signal, split into segments, with shape [n_segment, segment_size].
 
     Notes


### PR DESCRIPTION
Responds to #292 

Adds a function for applying amplitude modulation (`modulate_signal`) and a function to simulate amplitude modulated signals (`sim_modulated_signal`). 

Note that the original idea was to add `sim_modulated_oscillation`, but in the end, there is nothing really specific to applying amplitude modulation to an oscillatory signal, so this function might as well be more general. The only slight quirk, is that the only real place to put the general `sim_modulated_signal` is in the `combined` file - though it's not really a combined signal...

The modulate signal function applies amplitude modulation, and can be used like the following examples (note the two call signatures, allowing for a passing in a modulating signal, or a function name to create a modulating signal):

```
n_seconds = 10
fs = 1000
sig = sim_oscillation(n_seconds, fs, 10)
msig1 = modulate_signal(sig, 'sim_oscillation', fs, {'freq' : 1}) 
mod = sim_powerlaw(n_seconds, fs)
msig2 = modulate_signal(sig, ', fs, {})
```
This creates signals that look like this:
<img width="986" alt="Screen Shot 2022-01-28 at 11 00 38 PM" src="https://user-images.githubusercontent.com/7727566/151646553-35346887-f89b-41cc-bd2f-40b204c236c9.png">

The `sim_modulated_signal` function allows for directly simulating amplitude modulated signals, with the following creating the same kind of signals as above:
```
m2sig1 = sim_modulated_signal(n_seconds, fs,
                                                     'sim_oscillation', {'freq' : 10},
                                                     'sim_oscillation', {'freq' : 1})
m2sig2 = sim_modulated_signal(n_seconds, fs,
                                                     'sim_oscillation', {'freq' : 10},
                                                     'sim_powerlaw', {})
```