### PR TITLE
[MNT] - Update plot_time_series to make times optional

### DIFF
--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 
 from neurodsp.plts.style import style_plot
 from neurodsp.plts.utils import check_ax, savefig
+from neurodsp.utils.data import create_samples
 from neurodsp.utils.checks import check_param_options
 
 ###################################################################################################
@@ -20,8 +21,9 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
 
     Parameters
     ----------
-    times : 1d or 2d array, or list of 1d array
+    times : 1d or 2d array, or list of 1d array, or None
         Time definition(s) for the time series to be plotted.
+        If None, time series will be plotted in terms of samples instead of time.
     sigs : 1d or 2d array, or list of 1d array
         Time series to plot.
     labels : list of str, optional
@@ -48,8 +50,14 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
 
     ax = check_ax(ax, (15, 3))
 
-    times = repeat(times) if (isinstance(times, np.ndarray) and times.ndim == 1) else times
     sigs = [sigs] if (isinstance(sigs, np.ndarray) and sigs.ndim == 1) else sigs
+
+    xlabel = 'Time (s)'
+    if times is None:
+        times = create_samples(len(sigs[0]))
+        xlabel = 'Samples'
+
+    times = repeat(times) if (isinstance(times, np.ndarray) and times.ndim == 1) else times
 
     if labels is not None:
         labels = [labels] if not isinstance(labels, list) else labels
@@ -64,7 +72,7 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
     for time, sig, color, label in zip(times, sigs, colors, labels):
         ax.plot(time, sig, color=color, label=label)
 
-    ax.set_xlabel('Time (s)')
+    ax.set_xlabel(xlabel)
     ax.set_ylabel('Voltage (uV)')
 
 

--- a/neurodsp/tests/plts/test_time_series.py
+++ b/neurodsp/tests/plts/test_time_series.py
@@ -36,6 +36,11 @@ def test_plot_time_series(tsig_comb, tsig_burst):
                      save_fig=True, file_path=TEST_PLOTS_PATH,
                      file_name='test_plot_time_series-2arr.png')
 
+    # Test none input for times
+    plot_time_series(None, np.array([tsig_comb, tsig_burst]),
+                     save_fig=True, file_path=TEST_PLOTS_PATH,
+                     file_name='test_plot_time_series_notimes.png')
+
 @plot_test
 def test_plot_instantaneous_measure(tsig_comb):
 


### PR DESCRIPTION
Responds to #291 

This update means one doesn't have to pass in a times vector to `plot_time_series`, and if not provided it will be plotted in terms of samples instead. 

@ryanhammonds - I like your idea of simply supporting `plot_time_series(None, sig)`, which is what this does. 

My initial idea had be to support `plot_time_series(sig)`, in which case the function would check that the second input is empty, infer the first input is the signal and proceed from there. It would be easy to add this, but this is where it makes the API a little messy. Do we want to add this additional shortcut, or should we keep it like this?

Note that due to how they wrap `plot_time_series`, this update makes this option available to `plot_instantaneous_measure` and `plot_bursts` as well. 