### PR TITLE
[MNT] - Allow for passing figsize to plots

### DIFF
--- a/neurodsp/plts/filt.py
+++ b/neurodsp/plts/filt.py
@@ -10,7 +10,7 @@ from neurodsp.plts.utils import check_ax, savefig
 ###################################################################################################
 
 @savefig
-def plot_filter_properties(f_db, db, fs, impulse_response):
+def plot_filter_properties(f_db, db, fs, impulse_response, figsize=None):
     """Plot filter properties, including frequency response and filter kernel.
 
     Parameters
@@ -23,6 +23,8 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
         Sampling rate, in Hz.
     impulse_response : 1d array
         The impulse response of a filter. For an FIR filter, these are the filter coefficients.
+    figsize : tuple, optional
+        Size to create the figure.
 
     Examples
     --------
@@ -36,7 +38,7 @@ def plot_filter_properties(f_db, db, fs, impulse_response):
     >>> plot_filter_properties(f_db, db, fs, filter_coefs)
     """
 
-    _, ax = plt.subplots(1, 2, figsize=(10, 5))
+    _, ax = plt.subplots(1, 2, figsize=(10, 5) if not figsize else figsize)
 
     plot_frequency_response(f_db, db, ax=ax[0])
     plot_impulse_response(fs, impulse_response, ax=ax[1])
@@ -69,7 +71,7 @@ def plot_frequency_response(f_db, db, ax=None, **kwargs):
     >>> plot_frequency_response(f_db, db)
     """
 
-    ax = check_ax(ax, (5, 5))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (5, 5)))
 
     ax.plot(f_db, db, 'k')
 
@@ -105,7 +107,7 @@ def plot_impulse_response(fs, impulse_response, ax=None, **kwargs):
     >>> plot_impulse_response(fs, filter_coefs)
     """
 
-    ax = check_ax(ax, (5, 5))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (5, 5)))
 
     # Create a samples vector, center to zero, and convert to time
     samples = np.arange(len(impulse_response))

--- a/neurodsp/plts/rhythm.py
+++ b/neurodsp/plts/rhythm.py
@@ -37,7 +37,7 @@ def plot_swm_pattern(pattern, ax=None, **kwargs):
     >>> plot_swm_pattern(avg_window)
     """
 
-    ax = check_ax(ax, (4, 4))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (4, 4)))
 
     ax.plot(pattern, 'k')
 
@@ -78,7 +78,7 @@ def plot_lagged_coherence(freqs, lcs, ax=None, **kwargs):
     >>> plot_lagged_coherence(freqs, lag_cohs)
     """
 
-    ax = check_ax(ax, (6, 3))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (6, 3)))
 
     ax.plot(freqs, lcs, 'k.-')
 

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -45,7 +45,7 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
     >>> plot_power_spectra(freqs, powers)
     """
 
-    ax = check_ax(ax, (6, 6))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (6, 6)))
 
     freqs = repeat(freqs) if isinstance(freqs, np.ndarray) and freqs.ndim == 1 else freqs
     powers = [powers] if isinstance(powers, np.ndarray) and powers.ndim == 1 else powers
@@ -92,7 +92,7 @@ def plot_scv(freqs, scv, ax=None, **kwargs):
     >>> plot_scv(freqs, scv)
     """
 
-    ax = check_ax(ax, (5, 5))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (5, 5)))
 
     ax.loglog(freqs, scv)
 
@@ -129,7 +129,7 @@ def plot_scv_rs_lines(freqs, scv_rs, ax=None, **kwargs):
     >>> plot_scv_rs_lines(freqs, scv_rs)
     """
 
-    ax = check_ax(ax, (8, 8))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (8, 8)))
 
     ax.loglog(freqs, scv_rs, 'k', alpha=0.1)
     ax.loglog(freqs, np.mean(scv_rs, axis=1), lw=2)
@@ -171,7 +171,7 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs, ax=None, **kwargs):
     >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])
     """
 
-    ax = check_ax(ax, (10, 5))
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', (10, 5)))
 
     im = ax.imshow(np.log10(scv_rs), aspect='auto',
                    extent=(t_inds[0], t_inds[-1], freqs[-1], freqs[0]))
@@ -219,9 +219,9 @@ def plot_spectral_hist(freqs, power_bins, spectral_hist, spectrum_freqs=None,
     >>> plot_spectral_hist(freqs, bins, spect_hist)
     """
 
-    # Get axis, by default scaling figure height based on number of bins
+    # Get axis, with default of scaling figure height based on number of bins
     figsize = (8, 12 * len(power_bins) / len(freqs))
-    ax = check_ax(ax, figsize)
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', figsize))
 
     # Plot histogram intensity as image and automatically adjust aspect ratio
     im = ax.imshow(spectral_hist, extent=[freqs[0], freqs[-1], power_bins[0], power_bins[-1]],

--- a/neurodsp/plts/time_series.py
+++ b/neurodsp/plts/time_series.py
@@ -46,7 +46,7 @@ def plot_time_series(times, sigs, labels=None, colors=None, ax=None, **kwargs):
     >>> plot_time_series(times, sig)
     """
 
-    ax = check_ax(ax, (15, 3))
+    ax = check_ax(ax, kwargs.pop('figsize', (15, 3)))
 
     times = repeat(times) if (isinstance(times, np.ndarray) and times.ndim == 1) else times
     sigs = [sigs] if (isinstance(sigs, np.ndarray) and sigs.ndim == 1) else sigs

--- a/neurodsp/plts/timefrequency.py
+++ b/neurodsp/plts/timefrequency.py
@@ -46,7 +46,7 @@ def plot_timefrequency(times, freqs, powers, x_ticks=5, y_ticks=5, ax=None, **kw
     >>> plot_timefrequency(times, freqs, mwt)
     """
 
-    ax = check_ax(ax, None)
+    ax = check_ax(ax, figsize=kwargs.pop('figsize', None))
 
     if np.iscomplexobj(powers):
         powers = abs(powers)


### PR DESCRIPTION
Our plot functions all have default sizes, which could be bypassed by passing in an Axis object. This extends the flexibility for controlling figure size, by allowing for passing in a `figsize` argument directly to each plot argument. 

In general, this `figsize` argument is caught by `kwargs`, and when creating a new axis, the figures will still default to the same size they always have, but this can now be over-written by the `figsize` input. 