### PR TITLE
[WIP/ENH] - Add erp sim func

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -248,8 +248,8 @@ Aperiodic Signals
     sim_frac_gaussian_noise
     sim_frac_brownian_motion
 
-Transients & Cycles
-~~~~~~~~~~~~~~~~~~~
+Transients
+~~~~~~~~~~
 
 .. currentmodule:: neurodsp.sim.transients
 .. autosummary::
@@ -257,6 +257,10 @@ Transients & Cycles
 
     sim_synaptic_kernel
     sim_action_potential
+    sim_damped_erp
+
+Cycles
+~~~~~~
 
 .. currentmodule:: neurodsp.sim.cycles
 .. autosummary::

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -138,8 +138,8 @@ def sim_action_potential(n_seconds, fs, centers, stds, alphas, heights):
     return cycle
 
 
-def sim_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
-    """Simulate an ERP complex.
+def sim_damped_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
+    """Simulate an ERP complex as a decaying (damped) sine wave.
 
     Parameters
     ----------
@@ -169,11 +169,11 @@ def sim_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
     --------
     Simulate an ERP complex with a frequency of 7 Hz and a 50 ms decay time:
 
-    >>> erp = sim_erp(n_seconds=0.5, fs=500, amp=1, freq=7, decay=0.05)
+    >>> erp = sim_damped_erp(n_seconds=0.5, fs=500, amp=1, freq=7, decay=0.05)
 
     Simulate an ERP complex with a frequency of 10 Hz and a 25 ms decay time:
 
-    >>> erp = sim_erp(n_seconds=0.5, fs=500, amp=1, freq=10, decay=0.025)
+    >>> erp = sim_damped_erp(n_seconds=0.5, fs=500, amp=1, freq=10, decay=0.025)
 
     Reference
     ---------

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -138,7 +138,7 @@ def sim_action_potential(n_seconds, fs, centers, stds, alphas, heights):
     return cycle
 
 
-def sim_erp(n_seconds, fs, amp, freq, decay=0.05):
+def sim_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
     """Simulate an ERP complex.
 
     Parameters
@@ -151,8 +151,10 @@ def sim_erp(n_seconds, fs, amp, freq, decay=0.05):
         Amplitude of the ERP.
     freq : float
         Frequency of the ERP complex, in Hz.
-    decay : float
+    decay : float, optional, default: 0.05
         The exponential decay time of the ERP envelope.
+    time_start : float, optional, default: 0.
+        Start time, in seconds. Samples prior to start time are zero.
 
     Returns
     -------
@@ -182,7 +184,12 @@ def sim_erp(n_seconds, fs, amp, freq, decay=0.05):
 
     times = create_times(n_seconds, fs)
 
-    erp = amp * ((times) / decay) * np.exp(1 - (times) / decay) * \
+    _erp = amp * ((times) / decay) * np.exp(1 - (times) / decay) * \
         np.sin(2 * np.pi * freq * (times))
+
+    sample_start = int(time_start * fs)
+
+    erp = np.zeros_like(times)
+    erp[sample_start:] = _erp[:len(times)-sample_start]
 
     return erp

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -136,3 +136,53 @@ def sim_action_potential(n_seconds, fs, centers, stds, alphas, heights):
         cycle = np.sum(cycle, axis=0)
 
     return cycle
+
+
+def sim_erp(n_seconds, fs, amp, freq, decay=0.05):
+    """Simulate an ERP complex.
+
+    Parameters
+    ----------
+    n_seconds : float
+        Length of simulated kernel in seconds.
+    fs : float
+        Sampling rate of simulated signal, in Hz.
+    amp : float
+        Amplitude of the ERP.
+    freq : float
+        Frequency of the ERP complex, in Hz.
+    decay : float
+        The exponential decay time of the ERP envelope.
+
+    Returns
+    -------
+    erp : 1d array
+        Simulated ERP.
+
+    Notes
+    -----
+    This approach simulates simplified ERP complex as an exponentially decaying sine wave.
+
+    Examples
+    --------
+    Simulate an ERP complex with a frequency of 7 Hz and a 50 ms decay time:
+
+    >>> erp = sim_erp(n_seconds=0.5, fs=500, amp=1, freq=7, decay=0.05)
+
+    Simulate an ERP complex with a frequency of 10 Hz and a 25 ms decay time:
+
+    >>> erp = sim_erp(n_seconds=0.5, fs=500, amp=1, freq=10, decay=0.025)
+
+    Reference
+    ---------
+    .. [1] van Diepen, R. M., & Mazaheri, A. (2018). The Caveats of observing
+           Inter-Trial Phase-Coherence in Cognitive Neuroscience. Scientific Reports, 8(1).
+           DOI: https://doi.org/10.1038/s41598-018-20423-z
+    """
+
+    times = create_times(n_seconds, fs)
+
+    erp = amp * ((times) / decay) * np.exp(1 - (times) / decay) * \
+        np.sin(2 * np.pi * freq * (times))
+
+    return erp

--- a/neurodsp/tests/sim/test_transients.py
+++ b/neurodsp/tests/sim/test_transients.py
@@ -36,3 +36,9 @@ def test_sim_action_potential():
 
     cycle = sim_action_potential(N_SECONDS, FS, centers, stds, alphas, heights)
     check_sim_output(cycle, n_seconds=N_SECONDS)
+
+
+def test_sim_erp():
+
+    erp = sim_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05)
+    check_sim_output(erp, n_seconds=N_SECONDS)

--- a/neurodsp/tests/sim/test_transients.py
+++ b/neurodsp/tests/sim/test_transients.py
@@ -42,3 +42,6 @@ def test_sim_erp():
 
     erp = sim_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05)
     check_sim_output(erp, n_seconds=N_SECONDS)
+
+    erp = sim_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05, time_start=1)
+    assert not np.any(erp[:int(1 * FS)])

--- a/neurodsp/tests/sim/test_transients.py
+++ b/neurodsp/tests/sim/test_transients.py
@@ -38,10 +38,10 @@ def test_sim_action_potential():
     check_sim_output(cycle, n_seconds=N_SECONDS)
 
 
-def test_sim_erp():
+def test_sim_damped_erp():
 
-    erp = sim_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05)
+    erp = sim_damped_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05)
     check_sim_output(erp, n_seconds=N_SECONDS)
 
-    erp = sim_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05, time_start=1)
+    erp = sim_damped_erp(N_SECONDS, FS, amp=1, freq=5, decay=0.05, time_start=1)
     assert not np.any(erp[:int(1 * FS)])


### PR DESCRIPTION
Responds to #262 - adds a simulation function to create an ERP complex, simulated as a decaying (damped) sine wave. 

@ryanhammonds: could you take a quick look at this - do you think it's something worth adding? It's a very simple approach for adding ERPs, but seems worth adding something like this. If it looks good to you, the main potential update is to update it to vary the start time (I wasn't immediately clear on how to do this). 