### PR TITLE
[BUG] - Fix type-checking bug

### DIFF
--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -61,7 +61,7 @@ def check_filter_definition(pass_type, f_range):
     if pass_type in ('bandpass', 'bandstop'):
         if isinstance(f_range, (tuple, list)) and f_range[0] >= f_range[1]:
             raise ValueError('Second cutoff frequency must be greater than first.')
-        elif isinstance(f_range, (int, float)) or len(f_range) != 2:
+        elif isinstance(f_range, (int, float, np.number)) or len(f_range) != 2:
             raise ValueError('Two cutoff frequencies required for bandpass and bandstop filters.')
 
         # Map f_range to f_lo and f_hi
@@ -69,14 +69,14 @@ def check_filter_definition(pass_type, f_range):
 
     # For lowpass and highpass can be tuple or int/float
     if pass_type == 'lowpass':
-        if isinstance(f_range, (int, float)):
+        if isinstance(f_range, (int, float, np.number)):
             f_hi = f_range
         elif isinstance(f_range, (tuple, list)):
             f_hi = f_range[1]
         f_lo = None
 
     if pass_type == 'highpass':
-        if isinstance(f_range, (int, float)):
+        if isinstance(f_range, (int, float, np.number)):
             f_lo = f_range
         elif isinstance(f_range, (tuple, list)):
             f_lo = f_range[0]

--- a/neurodsp/filt/checks.py
+++ b/neurodsp/filt/checks.py
@@ -59,7 +59,7 @@ def check_filter_definition(pass_type, f_range):
     # Check that frequency cutoff inputs are appropriate
     #   For band filters, 2 inputs required & second entry must be > first
     if pass_type in ('bandpass', 'bandstop'):
-        if isinstance(f_range, (tuple, list)) and f_range[0] >= f_range[1]:
+        if isinstance(f_range, (tuple, list, np.ndarray)) and f_range[0] >= f_range[1]:
             raise ValueError('Second cutoff frequency must be greater than first.')
         elif isinstance(f_range, (int, float, np.number)) or len(f_range) != 2:
             raise ValueError('Two cutoff frequencies required for bandpass and bandstop filters.')
@@ -71,14 +71,14 @@ def check_filter_definition(pass_type, f_range):
     if pass_type == 'lowpass':
         if isinstance(f_range, (int, float, np.number)):
             f_hi = f_range
-        elif isinstance(f_range, (tuple, list)):
+        elif isinstance(f_range, (tuple, list, np.ndarray)):
             f_hi = f_range[1]
         f_lo = None
 
     if pass_type == 'highpass':
         if isinstance(f_range, (int, float, np.number)):
             f_lo = f_range
-        elif isinstance(f_range, (tuple, list)):
+        elif isinstance(f_range, (tuple, list, np.ndarray)):
             f_lo = f_range[0]
         f_hi = None
 

--- a/neurodsp/sim/combined.py
+++ b/neurodsp/sim/combined.py
@@ -64,7 +64,7 @@ def sim_combined(n_seconds, fs, components, component_variances=1):
     # Collect the sim function to use, and repeat variance if is single number
     components = {(get_sim_func(name) if isinstance(name, str) else name) : params \
                    for name, params in components.items()}
-    variances = repeat(component_variances) if isinstance(component_variances, (int, float)) \
+    variances = repeat(component_variances) if isinstance(component_variances, (int, float, np.number)) \
         else iter(component_variances)
 
     # Simulate each component of the signal

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -227,7 +227,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
     param_values = list(cycle_params.values())
 
     param_lengths = np.array([len(params) for params in param_values
-                              if isinstance(params, (list, np.ndarray))])
+                              if isinstance(params, (tuple, list, np.ndarray))])
 
     # Determine the number of cycles
     if isinstance(freqs, (np.ndarray, list)):
@@ -247,7 +247,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
 
     # Ensure all kwargs params are iterable
     for idx, param in enumerate(param_values):
-        if not isinstance(param, (list, np.ndarray)):
+        if not isinstance(param, (tuple, list, np.ndarray)):
             param_values[idx] = [param] * n_cycles
 
     param_values = np.array(param_values).transpose()

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -238,7 +238,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
         n_cycles = 1
 
     # Ensure freqs is iterable and an array
-    freqs = np.array([freqs] * n_cycles) if isinstance(freqs, (int, float)) else freqs
+    freqs = np.array([freqs] * n_cycles) if isinstance(freqs, (int, float, np.number)) else freqs
     freqs = np.array(freqs) if not isinstance(freqs, np.ndarray) else freqs
 
     # Ensure lengths of variable params are equal

--- a/neurodsp/utils/checks.py
+++ b/neurodsp/utils/checks.py
@@ -80,7 +80,7 @@ def check_n_cycles(n_cycles, len_cycles=None):
 
         n_cycles = repeat(n_cycles)
 
-    elif isinstance(n_cycles, (list, np.ndarray)):
+    elif isinstance(n_cycles, (tuple, list, np.ndarray)):
 
         for cycle in n_cycles:
             if cycle <= 0:

--- a/neurodsp/utils/checks.py
+++ b/neurodsp/utils/checks.py
@@ -73,7 +73,7 @@ def check_n_cycles(n_cycles, len_cycles=None):
         An iterable version of the number of cycles.
     """
 
-    if isinstance(n_cycles, (int, float)):
+    if isinstance(n_cycles, (int, float, np.number)):
 
         if n_cycles <= 0:
             raise ValueError('Number of cycles must be a positive number.')


### PR DESCRIPTION
This is a fix for an annoying type-checking bug that can arise. 

Specifically, it started from `check_filter_definition`, which (on current main), will fail if given a numpy type number. 

Example - this fails unexpectedly (and unclearly):
`check_filter_definition('lowpass', np.int64(10))`

Note that this line is a shortcut to see the problem (not a likely function call), but this does can arise in more natural cases, such as using `np.arange`:
```
for f_val in np.arange(1, 10):
    check_filter_definition('lowpass', f_val)
```

The cause of the bug is that we do type checks in line 70-83, which check for `int` or `float`, but a numpy number type doesn't get caught, the variables don't get assigned, and it all falls apart. So I added the type check of `np.number` here to fix it. 

I then updated the same idea in a couple other places, both for checking numbers, and checking collections / array_like.