### PR TITLE
[FIX] - Add fix for special case of rdsym

### DIFF
--- a/neurodsp/sim/cycles.py
+++ b/neurodsp/sim/cycles.py
@@ -159,9 +159,6 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
     n_samples = compute_nsamples(n_seconds, fs)
     half_sample = int(n_samples/2)
 
-    # Check for an odd number of samples (for half peaks, we need to fix this later)
-    remainder = n_samples % 2
-
     # Calculate number of samples rising
     n_rise = int(np.round(n_samples * rdsym))
     n_rise1 = int(np.ceil(n_rise/2))
@@ -171,9 +168,14 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
     n_decay = n_samples - n_rise
     n_decay1 = half_sample - n_rise1
 
+    # Check for an odd number of samples - if so we offset by one for half cycles
+    # Below we also check for special cases of rdsym, which similarly need offsetting
+    remainder = n_samples % 2
+
     # Create phase definition for cycle with both extrema being asymmetric
     if side == 'both':
 
+        n_rise1 -= 1 if rdsym == 1. else 0
         phase = np.hstack([np.linspace(0, np.pi/2, n_rise1 + 1),
                            np.linspace(np.pi/2, -np.pi/2, n_decay + 1)[1:-1],
                            np.linspace(-np.pi/2, 0, n_rise2 + 1)[:-1]])
@@ -181,6 +183,7 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
     # Create phase definition for cycle with only one extrema being asymmetric
     elif side == 'peak':
 
+        n_rise1 -= 1 if rdsym == 1. else 0
         half_sample += 1 if bool(remainder) else 0
         phase = np.hstack([np.linspace(0, np.pi/2, n_rise1 + 1),
                            np.linspace(np.pi/2, np.pi, n_decay1 + 1)[1:-1],
@@ -188,6 +191,7 @@ def sim_asine_cycle(n_seconds, fs, rdsym, side='both'):
 
     elif side == 'trough':
 
+        n_rise1 -= 1 if rdsym == 0. else 0
         half_sample -= 1 if not bool(remainder) else 0
         phase = np.hstack([np.linspace(0, np.pi, half_sample + 1)[:-1],
                            np.linspace(-np.pi, -np.pi/2, n_decay1 + 1),

--- a/neurodsp/tests/sim/test_cycles.py
+++ b/neurodsp/tests/sim/test_cycles.py
@@ -73,6 +73,12 @@ def test_sim_asine_cycle(side):
     cycle = sim_asine_cycle(N_SECONDS_CYCLE, FS_ODD, 0.25, side=side)
     check_sim_output(cycle, n_seconds=N_SECONDS_CYCLE, fs=FS_ODD)
 
+    # Check special cases of rdsym = {0., 1.} which can lead to a length error
+    cycle = sim_asine_cycle(N_SECONDS_CYCLE, FS, 0., side=side)
+    check_sim_output(cycle, n_seconds=N_SECONDS_CYCLE)
+    cycle = sim_asine_cycle(N_SECONDS_CYCLE, FS, 1., side=side)
+    check_sim_output(cycle, n_seconds=N_SECONDS_CYCLE)
+
 def test_sim_sawtooth_cycle():
 
     cycle = sim_sawtooth_cycle(N_SECONDS_CYCLE, FS, 0.75)


### PR DESCRIPTION
For `sim_asine_cycle`, there are special cases of rdsym value that can lead to an off by one error in terms computing the number of samples in the cycle. This comes from how we compute the number of samples based on rdsym value. 

For example, on main, the following code would get the wrong sample length (101 instead of 100):
`cyc = sim_asine_cycle2(0.1, 1000, 1., side='both')`

This can happen for 'peak' or 'both' when rdsym is 1., and for 'trough' when rdsym is 0.

This PR adds a check and fix for this issue, as well as some extra tests to keep an eye on this issue (note that these tests would fail on current main branch). 