### PR TITLE
[MNT] - Update utilities usage in sim/periodic

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -405,6 +405,7 @@ Data
     create_samples
     compute_nsamples
     compute_nseconds
+    compute_cycle_nseconds
     split_signal
 
 Outliers

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -4,7 +4,7 @@ from itertools import repeat
 
 import numpy as np
 
-from neurodsp.utils.data import compute_nsamples, create_times
+from neurodsp.utils.data import compute_nsamples, compute_cycle_nseconds, create_times
 from neurodsp.utils.checks import check_param_range, check_param_options
 from neurodsp.utils.decorators import normalize
 from neurodsp.sim.cycles import sim_cycle, sim_normalized_cycle
@@ -56,8 +56,7 @@ def sim_oscillation(n_seconds, fs, freq, cycle='sine', phase=0, **cycle_params):
     n_cycles = int(np.ceil(n_seconds * freq))
 
     # Compute the number of seconds per cycle for the requested frequency
-    #   The rounding is needed to get a value that works with the sampling rate
-    n_seconds_cycle = int(np.ceil(fs / freq)) / fs
+    n_seconds_cycle = compute_cycle_nseconds(freq, fs)
 
     # Create a single cycle of an oscillation, for the requested frequency
     cycle = sim_cycle(n_seconds_cycle, fs, cycle, phase, **cycle_params)
@@ -161,7 +160,7 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params=N
             burst_params[burst_param] = temp
 
     # Simulate a normalized cycle to use for bursts
-    n_seconds_cycle = 1/freq
+    n_seconds_cycle = compute_cycle_nseconds(freq, fs)
     osc_cycle = sim_normalized_cycle(n_seconds_cycle, fs, cycle, phase=phase, **cycle_params)
 
     # Calculate the number of cycles needed to tile the full signal
@@ -271,7 +270,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
         if start > n_samples or end > n_samples:
             break
 
-        n_seconds_cycle = int(np.ceil(fs / freq)) / fs
+        n_seconds_cycle = compute_cycle_nseconds(freq, fs)
         sig[start:end] = sim_normalized_cycle(n_seconds_cycle, fs, cycle, phase, **params)
 
     return sig

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -256,16 +256,16 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
     cycle_params = [dict(zip(param_keys, params)) for params in param_values]
     cycle_params = [{}] * len(freqs) if len(cycle_params) == 0 else cycle_params
 
-    # Determine start/end indices
-    cyc_lens = [int(np.ceil(1 / freq * fs)) for freq in freqs]
+    # Determine start/end indices, in samples
+    cyc_lens = [compute_nsamples(1 / freq, fs) for freq in freqs]
     ends = np.cumsum(cyc_lens, dtype=int)
     starts = [0, *ends[:-1]]
 
-    # Simulate
+    # Check and get the total number of signals, and initialize the output array
     n_samples = np.sum(cyc_lens) if n_seconds is None else compute_nsamples(n_seconds, fs)
-
     sig = np.zeros(n_samples)
 
+    # Simulate signal, adding each cycle with spefified parameters
     for freq, params, start, end in zip(freqs, cycle_params, starts, ends):
 
         if start > n_samples or end > n_samples:
@@ -460,7 +460,7 @@ def get_burst_samples(is_oscillating, fs, freq):
         Definition of whether each sample is part of a burst or not.
     """
 
-    n_samples_cycle = int(1/freq * fs)
+    n_samples_cycle = compute_nsamples(1 / freq, fs)
     bursts = np.repeat(is_oscillating, n_samples_cycle)
 
     return bursts

--- a/neurodsp/tests/utils/test_data.py
+++ b/neurodsp/tests/utils/test_data.py
@@ -54,6 +54,16 @@ def test_compute_nseconds(tsig):
     assert isinstance(n_seconds, float)
     assert n_seconds == N_SECONDS
 
+def test_compute_cycle_nseconds():
+
+    n_seconds10 = compute_cycle_nseconds(10)
+    assert isinstance(n_seconds10, float)
+    assert n_seconds10 == 0.1
+
+    n_seconds10fs = compute_cycle_nseconds(10, fs=1001)
+    assert isinstance(n_seconds10fs, float)
+    assert n_seconds10fs != n_seconds10
+
 def test_split_signal(tsig):
 
     chunks = split_signal(tsig, 100)

--- a/neurodsp/utils/data.py
+++ b/neurodsp/utils/data.py
@@ -110,6 +110,35 @@ def compute_nseconds(sig, fs):
     return len(sig) / fs
 
 
+def compute_cycle_nseconds(freq, fs=None):
+    """Compute the length, in seconds, for a single cycle at a particular frequency.
+
+    Parameters
+    ----------
+    fs :  float
+        Sampling rate, in Hz.
+    freq : float, optional
+        Oscillation frequency, in Hz.
+        If provided, this is used to get a cycle length optimized for the sampling rate.
+
+    Returns
+    -------
+    n_seconds : float
+        The number of seconds of a single cycle at the specified frequency.
+
+    Notes
+    -----
+    The rounding is used to get a value that works with the sampling rate.
+    """
+
+    if fs:
+        n_seconds = int(np.ceil(fs / freq)) / fs
+    else:
+        n_seconds = 1 / freq
+
+    return n_seconds
+
+
 def split_signal(sig, n_samples):
     """Split a signal into non-overlapping segments.
 

--- a/neurodsp/utils/data.py
+++ b/neurodsp/utils/data.py
@@ -115,10 +115,10 @@ def compute_cycle_nseconds(freq, fs=None):
 
     Parameters
     ----------
-    fs :  float
-        Sampling rate, in Hz.
-    freq : float, optional
+    freq : float
         Oscillation frequency, in Hz.
+    fs :  float, optional
+        Sampling rate, in Hz.
         If provided, this is used to get a cycle length optimized for the sampling rate.
 
     Returns


### PR DESCRIPTION
This PR is some minor clean-ups to using helper utilities in `sim/periodic`. The goal is to more consistently use helper utilities to make sure we are doing the same thing in the same ways. 

Updates:
- update to use `compute_nsamples` more consistently
- add a new helper function to compute the time length of a single cycle
- update to use `compute_cycle_nseconds` in simulation functions

Note for review: this should be a pretty straight forward update, I think, but given it changes some basic underlying estimations when simulating signals, it's probably worth keeping an eye on if this changes any sims in any unexpected ways (I haven't noticed anything so far). 