### PR TITLE
[MNT] - Add CI testing against python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env: 
+    env:
       MODULE_NAME: neurodsp
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         ],
     platforms = 'any',
     project_urls = {


### PR DESCRIPTION
This PR adds testing using Python version 3.10 to our continuous integration. 

Note: when I had a quick look for adding this, I saw some stuff about how writing "3.10" is required to enforce 3.10, otherwise it can end up with 3.1. I didn't check this, but seems to work, so I think this should be good. 