### PR TITLE
Modify test to fix brittle flakiness

### DIFF
--- a/neurodsp/utils/download.py
+++ b/neurodsp/utils/download.py
@@ -34,6 +34,7 @@ def check_data_file(filename, folder, url=DATA_URL):
         Name of the folder to save the datafile to.
     """
 
+    check_data_folder(folder)
     filepath = os.path.join(folder, filename)
 
     if not os.path.isfile(filepath):


### PR DESCRIPTION
One of the tests `test_check_data_file` inside the `test_download.py` module was found to be flaky (specifically, something called brittle flakiness), when using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin. A flaky test is a test that both passes and fails despite no changes to the code or the test itself. Brittle flakiness (defined as per [iFixFlakies](https://mir.cs.illinois.edu/winglam/publications/2019/ShiETAL19iFixFlakies.pdf)) is when a test runs fine when run in conjunction with the other tests in the same module but fails when run on its own. 

To reproduce: 
`pytest neurodsp/tests/utils/test_download.py::test_check_data_file`

All other tests inside `test_download.py` ran fine when run on their own. To fix, I just added a single call to `check_data_folder` inside the `check_data_file` function which is called in the `test_check_data_file` test. This downloads the required folder before checking for the file.

I'm aware that the tests might not be run on their own, but this makes the entire module more robust so it's just a small fix for you to consider.