### PR TITLE
[MNT] - Update action version numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,12 @@ jobs:
     # Tag ubuntu version to 20.04, in order to support python 3.6
     #   See issue: https://github.com/actions/setup-python/issues/544
     #   When ready to drop 3.6, can revert from 'ubuntu-20.04' -> 'ubuntu-latest'
+    runs-on: ubuntu-20.04
     env:
       MODULE_NAME: neurodsp
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -37,4 +37,4 @@ jobs:
       run: |
         pytest --doctest-modules --ignore=$MODULE_NAME/tests $MODULE_NAME
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # Tag ubuntu version to 20.04, in order to support python 3.6
+    #   See issue: https://github.com/actions/setup-python/issues/544
+    #   When ready to drop 3.6, can revert from 'ubuntu-20.04' -> 'ubuntu-latest'
     env:
       MODULE_NAME: neurodsp
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         ],
     platforms = 'any',
     project_urls = {


### PR DESCRIPTION
Updates CI tests for:
- pinning the Ubuntu version, to maintain support of py3.6 (which fails on ubuntu-latest)
- updates the versions of the actions (which addresses future deprecations)
- adds testing and lists support for python 3.11