### PR TITLE
[MNT] - Build & install related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore source release files
 /dist/*
-/neurodsp.egg-info/*
+/*.egg-info/*
 /build/*
 
 # Ignore notebook checkpoints

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSE requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 #   coverage            For running test coverage
 #   pylint              For running linting on code
 #   setuptools          For creating distributions
-#   twine		For checking and publishing distributions
+#   build               For creating distributions
+#   twine               For checking and publishing distributions
 #
 # The following command line utilities are required:
 #   cloc                For counting code
@@ -98,13 +99,13 @@ summary:
 # Create a distribution build of the module
 dist:
 	@printf "\n\nCREATING DISTRIBUTION BUILD...\n"
-	@python setup.py sdist bdist_wheel
+	@python -m build
 	@printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
 
 # Check a distribution build using twine
 check-dist:
 	@printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
-	twine check dist/*
+	@twine check dist/*
 	@printf "\n"
 
 # Clear out distribution files

--- a/neurodsp/tests/settings.py
+++ b/neurodsp/tests/settings.py
@@ -1,7 +1,7 @@
 """Default settings for tests."""
 
 import os
-import pkg_resources as pkg
+from pathlib import Path
 
 import numpy as np
 
@@ -35,5 +35,6 @@ EPS = 10**(-10)
 EPS_FILT = 10**(-3)
 
 # Set paths for test files
-BASE_TEST_FILE_PATH = pkg.resource_filename(__name__, 'test_files')
+TESTS_PATH = Path(os.path.abspath(os.path.dirname(__file__)))
+BASE_TEST_FILE_PATH = TESTS_PATH / 'test_files'
 TEST_PLOTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'plots')

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version = __version__,
     description = 'Digital signal processing for neural time series.',
     long_description = long_description,
+    long_description_content_type = 'text/x-rst',
     python_requires = '>=3.6',
     author = 'The Voytek Lab',
     author_email = 'voyteklab@gmail.com',


### PR DESCRIPTION
Updates:
- use `build` for distributions (see https://github.com/fooof-tools/fooof/pull/282/)
- drop use of `package_resources` (see https://github.com/fooof-tools/fooof/pull/281)

This is matching the updates to fooof in the PRs above, so shouldn't need another much review other than to check that we're happy to apply these updates here as well

Also, @ryanhammonds - I made these updates to ByCycle, but screwed up my branching and accidentally pushed to main. The two last commits on ByCycle do the same as here (https://github.com/bycycle-tools/bycycle/commits/main) - if this is good with you, we're all good - but if you have any thoughts / comments, let me know and I can revert!