### PR TITLE
[ENH] Zero padding + Welch's PSD

### DIFF
--- a/neurodsp/spectral/checks.py
+++ b/neurodsp/spectral/checks.py
@@ -54,27 +54,29 @@ def check_mt_settings(n_samples, fs, bandwidth, n_tapers):
     fs : float
         Sampling rate, in Hz.
     bandwidth : float or None
-        Bandwidth of the multitaper window, in Hz. If None, will use 
-        8 * fs / n_samples.
+        Bandwidth of the multitaper window, in Hz.
+        If None, will use 8 * fs / n_samples.
     n_tapers : int or None
-        Number of tapers to use. If None, will use bandwidth * n_samples / fs
+        Number of tapers to use.
+        If None, will use bandwidth * n_samples / fs.
 
     Returns
     -------
     nw : float
-        Standardized half bandwidth (used to compute DPSS)
+        Standardized half bandwidth (used to compute DPSS).
     n_tapers : int
         Number of tapers.
-    """ 
+    """
 
     # set bandwidth
     if bandwidth is None:
-        bandwidth = 8 * fs / n_samples # MNE default 
+        bandwidth = 8 * fs / n_samples # MNE default
 
     # check bandwidth - break if alpha < 1
     alpha = n_samples * bandwidth / (fs * 2)
     if alpha < 1:
-        raise ValueError("Bandwidth too narrow for signal length and sampling rate. Try increasing bandwidth. n_samples * bandwidth / (fs * 2) must be >1")
+        raise ValueError("Bandwidth too narrow for signal length and sampling rate. "
+                         "Try increasing bandwidth. n_samples * bandwidth / (fs * 2) must be >1.")
 
     # compute nw
     nw = bandwidth * n_samples / (fs * 2)

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -292,14 +292,13 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
     fs : float
         Sampling rate, in Hz.
     bandwidth : float, optional
-        Frequency bandwidth of multi-taper window function. Default is
-        8 * fs / n_samples.
+        Frequency bandwidth of multi-taper window function.
+        If not provided, defaults to 8 * fs / n_samples.
     n_tapers : int, optional
-        Number of slepian windows used to compute the spectrum. Default is
-        bandwidth * n_samples / fs.
-    low_bias : bool, optional
-        If True, only use tapers with concentration ratio > 0.9. Default is
-        True.
+        Number of slepian windows used to compute the spectrum.
+        If not provided, defaults to bandwidth * n_samples / fs.
+    low_bias : bool, optional, default: True
+        If True, only use tapers with concentration ratio > 0.9.
     eigenvalue_weighting : bool, optional
         If True, weight spectral estimates by the concentration ratio of
         their respective tapers before combining. Default is True.
@@ -313,8 +312,7 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
 
     Examples
     --------
-    Compute the power spectrum of a simulated time series using the
-    multitaper method:
+    Compute the power spectrum of a simulated time series using the multitaper method:
 
     >>> from neurodsp.sim import sim_combined
     >>> sig = sim_combined(n_seconds=10, fs=500,
@@ -331,19 +329,19 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
     nw, n_tapers = check_mt_settings(sig_len, fs, bandwidth, n_tapers)
 
     # Create slepian sequences
-    slepian_sequences, ratios = dpss(sig_len, nw, n_tapers,
-                                     return_ratios=True)
+    slepian_sequences, ratios = dpss(sig_len, nw, n_tapers, return_ratios=True)
 
     # Drop tapers with low concentration
     if low_bias:
         slepian_sequences = slepian_sequences[ratios > 0.9]
         ratios = ratios[ratios > 0.9]
         if len(slepian_sequences) == 0:
-            raise ValueError('No tapers with concentration ratio > 0.9. Could not compute spectrum with low_bias=True.')
+            raise ValueError("No tapers with concentration ratio > 0.9. "
+                             "Could not compute spectrum with low_bias=True.")
 
-    # Compute fourier on signal weighted by each slepian sequence
+    # Compute Fourier transform on signal weighted by each slepian sequence
     freqs = np.fft.rfftfreq(sig_len, 1. /fs)
-    spectra = np.abs(np.fft.rfft(slepian_sequences[:, np.newaxis]*sig))**2
+    spectra = np.abs(np.fft.rfft(slepian_sequences[:, np.newaxis] * sig)) ** 2
 
     # combine estimates to compute final spectrum
     if eigenvalue_weighting:

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -119,7 +119,7 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
 
 
 def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
-                           nperseg=None, noverlap=None, npad=None,
+                           nperseg=None, noverlap=None, nfft=None,
                            fast_len=False, f_range=None, outlier_percent=None):
     """Compute the power spectral density using Welch's method.
 
@@ -144,8 +144,9 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
     noverlap : int, optional
         Number of points to overlap between segments.
         If None, noverlap = nperseg // 8.
-    npad : int, optional
-        Number of samples to zero pad windows per side.
+    nfft : int, optional
+        Number of samples per window. Requires nfft > nperseg.
+        Windows are zero-padded by the difference, nfft - nperseg.
     fast_len : bool, optional, default: False
         Moves nperseg to the fastest length to reduce computation.
         See scipy.fft.next_fast_len for details.
@@ -186,7 +187,10 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
     nperseg, noverlap = check_spg_settings(fs, window, nperseg, noverlap)
 
     # Pad signal if requested
-    if npad is not None:
+    if nfft is not None and nfft < nperseg:
+        raise ValueError('nfft must be greater than nperseg.')
+    elif nfft is not None:
+        npad = nfft - nperseg
         noverlap = nperseg // 8 if noverlap is None else noverlap
         sig, nperseg, noverlap = window_pad(sig, nperseg, noverlap, npad, fast_len)
     elif fast_len:

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -71,7 +71,8 @@ def compute_spectrum(sig, fs, method='welch', **kwargs):
 
 
 SPECTRUM_INPUTS = {
-    'welch' : ['avg_type', 'window', 'nperseg', 'noverlap', 'f_range', 'outlier_percent'],
+    'welch' : ['avg_type', 'window', 'nperseg', 'noverlap', 'nfft', \
+               'fast_len', 'f_range', 'outlier_percent'],
     'wavelet' : ['freqs', 'avg_type', 'n_cycles', 'scaling', 'norm'],
     'medfilt' : ['filt_len', 'f_range'],
 }
@@ -297,7 +298,7 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
         Number of slepian windows used to compute the spectrum. Default is
         bandwidth * n_samples / fs.
     low_bias : bool, optional
-        If True, only use tapers with concentration ratio > 0.9. Default is 
+        If True, only use tapers with concentration ratio > 0.9. Default is
         True.
     eigenvalue_weighting : bool, optional
         If True, weight spectral estimates by the concentration ratio of
@@ -312,7 +313,7 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
 
     Examples
     --------
-    Compute the power spectrum of a simulated time series using the 
+    Compute the power spectrum of a simulated time series using the
     multitaper method:
 
     >>> from neurodsp.sim import sim_combined

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -15,7 +15,7 @@ from neurodsp.utils.decorators import multidim
 from neurodsp.utils.checks import check_param_options
 from neurodsp.utils.outliers import discard_outliers
 from neurodsp.timefrequency.wavelets import compute_wavelet_transform
-from neurodsp.spectral.utils import trim_spectrum
+from neurodsp.spectral.utils import trim_spectrum, window_pad
 from neurodsp.spectral.checks import check_spg_settings
 
 ###################################################################################################
@@ -118,7 +118,7 @@ def compute_spectrum_wavelet(sig, fs, freqs, avg_type='mean', **kwargs):
 
 
 def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
-                           nperseg=None, noverlap=None,
+                           nperseg=None, noverlap=None, npad=None,
                            f_range=None, outlier_percent=None):
     """Compute the power spectral density using Welch's method.
 
@@ -178,6 +178,12 @@ def compute_spectrum_welch(sig, fs, avg_type='mean', window='hann',
 
     # Calculate the short time Fourier transform with signal.spectrogram
     nperseg, noverlap = check_spg_settings(fs, window, nperseg, noverlap)
+
+    # Pad signal if requested
+    if npad is not None:
+        sig, nperseg, noverlap = window_pad(sig, nperseg, noverlap, npad)
+
+    # Compute spectrogram
     freqs, _, spg = spectrogram(sig, fs, window, nperseg, noverlap)
 
     # Throw out outliers if indicated

--- a/neurodsp/tests/spectral/test_power.py
+++ b/neurodsp/tests/spectral/test_power.py
@@ -61,7 +61,7 @@ def test_compute_spectrum_welch(tsig, tsig_sine):
 
     # Test zero padding
     freqs, spectrum = compute_spectrum(
-        np.tile(tsig, (2, 1)), FS, nperseg=100, noverlap=0, npad=1000, f_range=(1, 200)
+        np.tile(tsig, (2, 1)), FS, nperseg=100, noverlap=0, nfft=1000, f_range=(1, 200)
     )
     assert np.all(spectrum[0] == spectrum[1])
 

--- a/neurodsp/tests/spectral/test_power.py
+++ b/neurodsp/tests/spectral/test_power.py
@@ -59,6 +59,12 @@ def test_compute_spectrum_welch(tsig, tsig_sine):
     expected_answer = np.zeros_like(psd_welch[0:FREQ_SINE])
     assert np.allclose(psd_welch[0:FREQ_SINE], expected_answer, atol=EPS)
 
+    # Test zero padding
+    freqs, spectrum = compute_spectrum(
+        np.tile(tsig, (2, 1)), FS, nperseg=100, noverlap=0, npad=1000, f_range=(1, 200)
+    )
+    np.all(spectrum[0] == spectrum[1])
+
 def test_compute_spectrum_wavelet(tsig):
 
     freqs, spectrum = compute_spectrum_wavelet(tsig, FS, freqs=FREQS_ARR, avg_type='mean')

--- a/neurodsp/tests/spectral/test_power.py
+++ b/neurodsp/tests/spectral/test_power.py
@@ -63,7 +63,7 @@ def test_compute_spectrum_welch(tsig, tsig_sine):
     freqs, spectrum = compute_spectrum(
         np.tile(tsig, (2, 1)), FS, nperseg=100, noverlap=0, npad=1000, f_range=(1, 200)
     )
-    np.all(spectrum[0] == spectrum[1])
+    assert np.all(spectrum[0] == spectrum[1])
 
 def test_compute_spectrum_wavelet(tsig):
 

--- a/neurodsp/tests/spectral/test_utils.py
+++ b/neurodsp/tests/spectral/test_utils.py
@@ -40,3 +40,24 @@ def test_trim_spectrogram():
     f_ext, t_ext, p_ext = trim_spectrogram(freqs, times, pows, f_range=[6, 8], t_range=None)
     assert_equal(f_ext, np.array([6, 7, 8]))
     assert_equal(t_ext, times)
+
+def test_window_pad():
+
+    nperseg = 100
+    noverlap = 10
+    npad = 1000
+
+    sig = np.random.rand(1000)
+
+    sig_windowed, _nperseg, _noverlap = window_pad(sig, nperseg, noverlap, npad)
+
+    # Overlap was handled correctly b/w the first two windows
+    assert np.all(sig_windowed[npad:npad+nperseg][-noverlap:] ==
+        sig_windowed[(3*npad)+nperseg:(3*npad)+nperseg+noverlap])
+
+    # Updated nperseg has no remainder
+    nwin = (len(sig_windowed) / nperseg)
+    assert nwin == int(nwin)
+
+    # Ensure updated nperseg is correct
+    assert _nperseg == nperseg + (2*npad)

--- a/neurodsp/tests/spectral/test_utils.py
+++ b/neurodsp/tests/spectral/test_utils.py
@@ -1,10 +1,11 @@
 """Tests for neurodsp.spectral.utils."""
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_equal
 
 from neurodsp.tests.settings import FS
-
 from neurodsp.spectral.utils import *
 
 ###################################################################################################
@@ -41,7 +42,9 @@ def test_trim_spectrogram():
     assert_equal(f_ext, np.array([6, 7, 8]))
     assert_equal(t_ext, times)
 
-def test_window_pad():
+
+@pytest.mark.parametrize("fast_len", [True, False])
+def test_window_pad(fast_len):
 
     nperseg = 100
     noverlap = 10
@@ -49,7 +52,7 @@ def test_window_pad():
 
     sig = np.random.rand(1000)
 
-    sig_windowed, _nperseg, _noverlap = window_pad(sig, nperseg, noverlap, npad)
+    sig_windowed, _nperseg, _noverlap = window_pad(sig, nperseg, noverlap, npad, fast_len)
 
     # Overlap was handled correctly b/w the first two windows
     assert np.all(sig_windowed[npad:npad+nperseg][-noverlap:] ==

--- a/neurodsp/tests/spectral/test_utils.py
+++ b/neurodsp/tests/spectral/test_utils.py
@@ -63,4 +63,4 @@ def test_window_pad(fast_len):
     assert nwin == int(nwin)
 
     # Ensure updated nperseg is correct
-    assert _nperseg == nperseg + (2*npad)
+    assert _nperseg == nperseg + npad


### PR DESCRIPTION
Adds ability to zeropad windows used in Welch's psd via a `npad` kwarg. This can result in smoother spectra. Working on timescales led me to think autoregressive PSD was a smoother method, but it really was the process of zero padding prior to taking the fft that lead to a smooth spectra. Similarily, zero padding the signal prior to fft is similar to zero padding either AR or ACF coefficients prior to fft'ing.

Here's an example using timescales (orange is a zeropadded welch's spectrum), but it also works for powerlaws.

<img width="390" alt="Screenshot 2023-09-02 at 2 23 25 PM" src="https://github.com/neurodsp-tools/neurodsp/assets/34786005/ac09ff4e-3a97-489a-b24f-88d861145f31">


```python
import numpy as np
import matplotlib.pyplot as plt
from neurodsp.spectral import compute_spectrum_welch
from neurodsp.sim import sim_synaptic_current

# Simulate timescale
np.random.seed(0)

n_seconds = 5
fs = 1000
sig = sim_synaptic_current(n_seconds, fs, tau_d=0.01)

# Default Welch
f, p = compute_spectrum_welch(sig, fs, f_range=(1, 200))
plt.loglog(f, p, alpha=.5, label='Default Welch')

# Smoothed Welch
nperseg = 25
noverlap = 0
nfft = 2000

f, p = compute_spectrum_welch(sig, fs, nperseg=nperseg, noverlap=0, nfft=nfft, f_range=(1, 200))
plt.loglog(f, p * 20, label='Zero Padded (Smoothed) Spectrum')
plt.legend();
```