### PR TITLE
[MNT] - Fix typos

### DIFF
--- a/neurodsp/sim/aperiodic.py
+++ b/neurodsp/sim/aperiodic.py
@@ -436,7 +436,7 @@ def sim_frac_brownian_motion(n_seconds, fs, exponent=-2, hurst=None):
     The time series can be specified with either a desired power law exponent,
     or alternatively with a specified Hurst parameter.
 
-    Note that when specifying there can be some bias leading to a steeper than expected
+    Note that when specifying exponent there can be some bias leading to a steeper than expected
     spectrum of the simulated signal. This bias is higher for exponent values near to 1,
     and may be more severe in shorter signals.
 

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -264,7 +264,7 @@ def sim_variable_oscillation(n_seconds, fs, freqs, cycle='sine', phase=0, **cycl
     n_samples = np.sum(cyc_lens) if n_seconds is None else compute_nsamples(n_seconds, fs)
     sig = np.zeros(n_samples)
 
-    # Simulate signal, adding each cycle with spefified parameters
+    # Simulate signal, adding each cycle with specified parameters
     for freq, params, start, end in zip(freqs, cycle_params, starts, ends):
 
         if start > n_samples or end > n_samples:
@@ -290,8 +290,8 @@ def sim_damped_oscillation(n_seconds, fs, freq, gamma, growth=None):
     gamma : float
         Parametric dampening coefficient.
     growth : float, optional, default: None
-        Logistic growth rate to smooth the heaviside step function. If None,
-        a non-smoothed heaviside is used.
+        Logistic growth rate to smooth the Heaviside step function.
+        If None, a non-smoothed Heaviside is used.
 
     Returns
     -------
@@ -358,7 +358,7 @@ def make_bursts(n_seconds, fs, is_oscillating, cycle):
 
         # If set as an oscillating cycle, add cycle to signal
         #   The sample check is to check there are enough samples left to add a full cycle
-        #   If there are not, this skipps the add, leaving zeros instead of adding part of a cycle
+        #   If there are not, this skips the add, leaving zeros instead of adding part of a cycle
         if is_osc and sig_ind + n_samples_cycle < n_samples:
             burst_sig[sig_ind:sig_ind+n_samples_cycle] = cycle
 

--- a/neurodsp/sim/transients.py
+++ b/neurodsp/sim/transients.py
@@ -89,7 +89,7 @@ def sim_action_potential(n_seconds, fs, centers, stds, alphas, heights):
     stds : array-like or float
         Standard deviations of the gaussian kernels, in seconds.
     alphas : array-like or float
-        Magnitiude and direction of the skew.
+        Magnitude and direction of the skew.
     heights : array-like or float
         Maximum value of the cycles.
 
@@ -171,7 +171,7 @@ def sim_damped_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
 
     Notes
     -----
-    This approach simulates simplified ERP complex as an exponentially decaying sine wave.
+    This approach simulates a simplified ERP complex as an exponentially decaying sine wave.
 
     Examples
     --------
@@ -183,8 +183,8 @@ def sim_damped_erp(n_seconds, fs, amp, freq, decay=0.05, time_start=0.):
 
     >>> erp = sim_damped_erp(n_seconds=0.5, fs=500, amp=1, freq=10, decay=0.025)
 
-    Reference
-    ---------
+    References
+    ----------
     .. [1] van Diepen, R. M., & Mazaheri, A. (2018). The Caveats of observing
            Inter-Trial Phase-Coherence in Cognitive Neuroscience. Scientific Reports, 8(1).
            DOI: https://doi.org/10.1038/s41598-018-20423-z


### PR DESCRIPTION
Quick check / update for some references. 

Most notably, updated 'Reference' -> 'References' in a docstring, as I happened to notice this typo leads to the section not appearing in the rendered docstring. 