### PR TITLE
[MNT] - Update filter type checks & inference

### DIFF
--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -42,21 +42,21 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type=None,
     return_filter : bool, optional, default: False
         If True, return the filter coefficients.
     **filter_kwargs
-        For FIR filters:
-            n_cycles : float, optional
-                Filter length, in number of cycles, defined at 'f_lo' frequency, if using an FIR filter.
-                Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
-                If not provided, and `n_seconds` is also not defined, defaults to 3.
-            n_seconds : float, optional
-                Filter length, in seconds, if using an FIR filter.
-                Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
-            remove_edges : bool, optional, default: True
-                If True, replace samples within half the kernel length to be np.nan.
-                Only used for FIR filters.
-        For IIR filters:
-            butterworth_order : int, optional
-                Order of the butterworth filter, if using an IIR filter.
-                See input 'N' in scipy.signal.butter.
+        Additional parameters for the filtering function, specific to filtering type.
+
+        | For FIR filters, can include:
+        |    n_cycles : float, optional
+        |        Filter length, in number of cycles, defined at 'f_lo' frequency.
+        |        Either `n_cycles` or `n_seconds` can be set for the filter length, but not both.
+        |        If not provided, and `n_seconds` is also not defined, defaults to 3.
+        |    n_seconds : float, optional
+        |        Filter length, in seconds.
+        |        Either `n_cycles` or `n_seconds` can be set for the filter length, but not both.
+        |    remove_edges : bool, optional, default: True
+        |        If True, replace samples within half the kernel length to be np.nan.
+        | For IIR filters, can include:
+        |    butterworth_order : int, optional
+        |        Order of the butterworth filter. See input 'N' in scipy.signal.butter.
 
     Returns
     -------

--- a/neurodsp/filt/filter.py
+++ b/neurodsp/filt/filter.py
@@ -10,7 +10,7 @@ from neurodsp.utils.checks import check_param_options
 ###################################################################################################
 
 def filter_signal(sig, fs, pass_type, f_range, filter_type=None,
-                  n_cycles=3, n_seconds=None, remove_edges=True, butterworth_order=None,
+                  n_cycles=None, n_seconds=None, remove_edges=True, butterworth_order=None,
                   print_transitions=False, plot_properties=False, return_filter=False):
     """Apply a bandpass, bandstop, highpass, or lowpass filter to a neural signal.
 
@@ -32,12 +32,13 @@ def filter_signal(sig, fs, pass_type, f_range, filter_type=None,
         For 'bandpass' & 'bandstop', must be a tuple.
         For 'lowpass' or 'highpass', can be a float that specifies pass frequency, or can be
         a tuple and is assumed to be (None, f_hi) for 'lowpass', and (f_lo, None) for 'highpass'.
-    n_cycles : float, optional, default: 3
-        Length of filter, in number of cycles, at the 'f_lo' frequency, if using an FIR filter.
-        This parameter is overwritten by `n_seconds`, if provided.
+    n_cycles : float, optional
+        Filter length, in number of cycles, defined at 'f_lo' frequency, if using an FIR filter.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
+        If not provided, and `n_seconds` is also not defined, defaults to 3.
     n_seconds : float, optional
-        Length of filter, in seconds, if using an FIR filter.
-        This parameter overwrites `n_cycles`.
+        Filter length, in seconds, if using an FIR filter.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
     filter_type : {'fir', 'iir'}, optional
         Whether to use an FIR or IIR filter. IIR option is a butterworth filter.
         If None, type is inferred from input parameters, and/or defaults to FIR.

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -39,7 +39,8 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
         Length of filter, in number of cycles, defined at the 'f_lo' frequency.
         This parameter is overwritten by `n_seconds`, if provided.
     n_seconds : float, optional
-        Length of filter, in seconds. This parameter overwrites `n_cycles`.
+        Length of filter, in seconds.
+        This parameter overwrites `n_cycles` if provided.
     remove_edges : bool, optional
         If True, replace samples within half the kernel length to be np.nan.
     print_transitions : bool, optional, default: False
@@ -157,7 +158,8 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
         Length of filter, in number of cycles, defined at the 'f_lo' frequency.
         This parameter is overwritten by `n_seconds`, if provided.
     n_seconds : float or None, optional
-        Length of filter, in seconds. This parameter overwrites `n_cycles`.
+        Length of filter, in seconds.
+        This parameter overwrites `n_cycles` if provided.
 
     Returns
     -------
@@ -204,6 +206,7 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
         Length of filter, in number of cycles, defined at the 'f_lo' frequency.
     n_seconds : float or None, optional
         Length of filter, in seconds.
+        If provided, this overwrites `n_cycles`, and is used to compute the filter length.
 
     Returns
     -------

--- a/neurodsp/filt/fir.py
+++ b/neurodsp/filt/fir.py
@@ -13,8 +13,9 @@ from neurodsp.filt.checks import (check_filter_definition, check_filter_properti
 ###################################################################################################
 ###################################################################################################
 
-def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, remove_edges=True,
-                      print_transitions=False, plot_properties=False, return_filter=False):
+def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=None, n_seconds=None,
+                      remove_edges=True, print_transitions=False, plot_properties=False,
+                      return_filter=False):
     """Apply an FIR filter to a signal.
 
     Parameters
@@ -35,12 +36,13 @@ def filter_signal_fir(sig, fs, pass_type, f_range, n_cycles=3, n_seconds=None, r
         For 'bandpass' & 'bandstop', must be a tuple.
         For 'lowpass' or 'highpass', can be a float that specifies pass frequency, or can be
         a tuple and is assumed to be (None, f_hi) for 'lowpass', and (f_lo, None) for 'highpass'.
-    n_cycles : float, optional, default: 3
-        Length of filter, in number of cycles, defined at the 'f_lo' frequency.
-        This parameter is overwritten by `n_seconds`, if provided.
+    n_cycles : float, optional
+        Filter length, in number of cycles, defined at the 'f_lo' frequency.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
+        If not provided, and `n_seconds` is also not defined, defaults to 3.
     n_seconds : float, optional
-        Length of filter, in seconds.
-        This parameter overwrites `n_cycles` if provided.
+        Filter length, in seconds.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
     remove_edges : bool, optional
         If True, replace samples within half the kernel length to be np.nan.
     print_transitions : bool, optional, default: False
@@ -135,7 +137,7 @@ def apply_fir_filter(sig, filter_coefs):
     return convolve(sig, filter_coefs, mode='same')
 
 
-def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
+def design_fir_filter(fs, pass_type, f_range, n_cycles=None, n_seconds=None):
     """Design an FIR filter.
 
     Parameters
@@ -154,12 +156,13 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
         For 'bandpass' & 'bandstop', must be a tuple.
         For 'lowpass' or 'highpass', can be a float that specifies pass frequency, or can be
         a tuple and is assumed to be (None, f_hi) for 'lowpass', and (f_lo, None) for 'highpass'.
-    n_cycles : float, optional, default: 3
-        Length of filter, in number of cycles, defined at the 'f_lo' frequency.
-        This parameter is overwritten by `n_seconds`, if provided.
-    n_seconds : float or None, optional
-        Length of filter, in seconds.
-        This parameter overwrites `n_cycles` if provided.
+    n_cycles : float, optional
+        Filter length, in number of cycles, defined at the 'f_lo' frequency.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
+        If not provided, and `n_seconds` is also not defined, defaults to 3.
+    n_seconds : float, optional
+        Filter length, in seconds.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
 
     Returns
     -------
@@ -173,8 +176,12 @@ def design_fir_filter(fs, pass_type, f_range, n_cycles=3, n_seconds=None):
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     """
 
-    # Check filter definition
     f_lo, f_hi = check_filter_definition(pass_type, f_range)
+
+    # Default to a filter length of `n_cycles` of 3, if nothing otherwise set
+    if n_cycles is None and n_seconds is None:
+        n_cycles = 3
+
     filt_len = compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles, n_seconds)
 
     if pass_type == 'bandpass':
@@ -202,16 +209,22 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
         The lower frequency range of the filter, specifying the highpass frequency, if specified.
     f_hi : float or None
         The higher frequency range of the filter, specifying the lowpass frequency, if specified.
-    n_cycles : float or None, optional
-        Length of filter, in number of cycles, defined at the 'f_lo' frequency.
-    n_seconds : float or None, optional
-        Length of filter, in seconds.
-        If provided, this overwrites `n_cycles`, and is used to compute the filter length.
+    n_cycles : float, optional
+        Filter length, in number of cycles, defined at the 'f_lo' frequency.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
+    n_seconds : float, optional
+        Filter length, in seconds.
+        Either `n_cycles` or `n_seconds` can be defined to set the filter length, but not both.
 
     Returns
     -------
     filt_len : int
         The length of the specified filter.
+
+    Raises
+    ------
+    ValueError
+        If both `n_cycles` & `n_seconds` are defined, leading to a conflict in filter length.
 
     Examples
     --------
@@ -219,6 +232,10 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
 
     >>> filt_len = compute_filter_length(fs=500, pass_type='bandpass', f_lo=1, f_hi=25, n_cycles=3)
     """
+
+    # Check for a conflict in defining length from having both `n_cycles` & `n_seconds`
+    if n_cycles is not None and n_seconds is not None:
+        raise ValueError('Either `n_cycles` or `n_seconds` can be defined, but not both.')
 
     # Compute filter length if specified in seconds
     if n_seconds is not None:
@@ -232,7 +249,7 @@ def compute_filter_length(fs, pass_type, f_lo, f_hi, n_cycles=None, n_seconds=No
     else:
         raise ValueError('Either `n_cycles` or `n_seconds` needs to be defined.')
 
-    # Typecast filter length to an integer, rounding up & force length to be odd
+    # Typecast filter length to an integer, rounding up & forcing length to be odd
     filt_len = int(np.ceil(filt_len))
     if filt_len % 2 == 0:
         filt_len = filt_len + 1

--- a/neurodsp/tests/filt/test_checks.py
+++ b/neurodsp/tests/filt/test_checks.py
@@ -54,7 +54,7 @@ def test_check_filter_properties():
 
     # Check failing filter - insufficient attenuation
     with warnings.catch_warnings(record=True) as warn:
-        filter_coefs = design_fir_filter(FS, 'bandstop', (8, 12))
+        filter_coefs = design_fir_filter(FS, 'bandstop', (8, 12), n_cycles=3)
         passes = check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
     assert passes is False
     assert len(warn) == 1
@@ -62,7 +62,7 @@ def test_check_filter_properties():
 
     # Check failing filter - transition bandwidth
     with warnings.catch_warnings(record=True) as warn:
-        filter_coefs = design_fir_filter(FS, 'bandpass', (20, 21))
+        filter_coefs = design_fir_filter(FS, 'bandpass', (20, 21), n_cycles=3)
         passes = check_filter_properties(filter_coefs, 1, FS, 'bandpass', (8, 12))
     assert passes is False
     assert len(warn) == 1

--- a/neurodsp/tests/filt/test_filter.py
+++ b/neurodsp/tests/filt/test_filter.py
@@ -7,7 +7,6 @@ import numpy as np
 from neurodsp.tests.settings import FS, F_RANGE
 
 from neurodsp.filt.filter import *
-from neurodsp.filt.filter import _iir_checks
 
 ###################################################################################################
 ###################################################################################################
@@ -24,17 +23,3 @@ def test_filter_signal(tsig):
     sigs = np.array([tsig, tsig])
     outs = filter_signal(sigs, FS, 'bandpass', F_RANGE, remove_edges=False)
     assert np.diff(outs, axis=0).sum() == 0
-
-def test_iir_checks():
-
-    # Check catch for having n_seconds defined
-    with raises(ValueError):
-        _iir_checks(1, 3, None)
-
-    # Check catch for not having butterworth_order defined
-    with raises(ValueError):
-        _iir_checks(None, None, None)
-
-    # Check catch for having remove_edges defined
-    with warns(UserWarning):
-        _iir_checks(None, 3, True)

--- a/neurodsp/tests/filt/test_filter.py
+++ b/neurodsp/tests/filt/test_filter.py
@@ -7,6 +7,7 @@ import numpy as np
 from neurodsp.tests.settings import FS, F_RANGE
 
 from neurodsp.filt.filter import *
+from neurodsp.filt.filter import _filter_input_checks
 
 ###################################################################################################
 ###################################################################################################
@@ -23,3 +24,25 @@ def test_filter_signal(tsig):
     sigs = np.array([tsig, tsig])
     outs = filter_signal(sigs, FS, 'bandpass', F_RANGE, remove_edges=False)
     assert np.diff(outs, axis=0).sum() == 0
+
+def test_filter_input_checks():
+
+    fir_inputs = {'n_cycles' : 5, 'remove_edges' : False}
+    _filter_input_checks('fir', fir_inputs)
+
+    iir_inputs = {'butterworth_order' : 7}
+    _filter_input_checks('iir', iir_inputs)
+
+    mixed_inputs = {'n_cycles' : 5, 'butterworth_order' : 7}
+    extra_inputs = {'n_cycles' : 5, 'nonsense_input' : True}
+
+    with raises(AssertionError):
+        _filter_input_checks('fir', iir_inputs)
+    with raises(AssertionError):
+        _filter_input_checks('iir', fir_inputs)
+    with raises(AssertionError):
+        _filter_input_checks('fir', mixed_inputs)
+    with raises(AssertionError):
+        _filter_input_checks('fir', mixed_inputs)
+    with raises(AssertionError):
+        _filter_input_checks('fir', extra_inputs)

--- a/neurodsp/tests/filt/test_fir.py
+++ b/neurodsp/tests/filt/test_fir.py
@@ -44,7 +44,7 @@ def test_design_fir_filter():
                   'lowpass' : (None, 5), 'highpass' : (5, None)}
 
     for pass_type, f_range in test_filts.items():
-        filter_coefs = design_fir_filter(FS, pass_type, f_range)
+        filter_coefs = design_fir_filter(FS, pass_type, f_range, n_cycles=3)
 
 def test_apply_fir_filter(tsig):
 
@@ -61,22 +61,23 @@ def test_compute_filter_length():
     #   n_seconds here is chosen to create expected odd filt_len, without needing rounding up
     n_seconds = 1.75
     expected_filt_len = n_seconds * fs
-    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi,
-                                     n_cycles=None, n_seconds=n_seconds)
+    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi, n_seconds=n_seconds)
     assert filt_len == expected_filt_len
 
     # Check filt_len, if defined using n_cycles
     n_cycles = 5
     expected_filt_len = int(np.ceil(fs * n_cycles / f_lo))
-    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi,
-                                     n_cycles=n_cycles, n_seconds=None)
+    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi, n_cycles=n_cycles)
     assert filt_len == expected_filt_len
 
     # Check filt_len, if expected to be rounded up to be odd
     n_cycles = 4
     expected_filt_len = int(np.ceil(fs * n_cycles / f_lo)) + 1
-    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi,
-                                     n_cycles=n_cycles, n_seconds=None)
+    filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi, n_cycles=n_cycles)
     assert filt_len == expected_filt_len
     with raises(ValueError):
         filt_len = compute_filter_length(fs, 'bandpass', f_lo, f_hi)
+
+    # Test error with inconsistent inputs
+    with raises(ValueError):
+        compute_filter_length(fs, 'bandpass', f_lo, f_hi, n_cycles=3, n_seconds=2.0)

--- a/neurodsp/tests/filt/test_utils.py
+++ b/neurodsp/tests/filt/test_utils.py
@@ -19,7 +19,7 @@ def test_infer_passtype():
 
 def test_compute_frequency_response():
 
-    filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12))
+    filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12), n_cycles=3)
     f_db, db = compute_frequency_response(filter_coefs, 1, FS)
 
     with raises(ValueError):
@@ -33,7 +33,7 @@ def test_compute_pass_band():
 
 def test_compute_transition_band():
 
-    filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12))
+    filter_coefs = design_fir_filter(FS, 'bandpass', (8, 12), n_cycles=3)
     f_db, db = compute_frequency_response(filter_coefs, 1, FS)
     trans_band = compute_transition_band(f_db, db)
 


### PR DESCRIPTION
Responds to #321 

Previously, one could end up with an inconsistent set of input parameters to the general `filter_signal` function - for example, passing in `butterworth_order` without explicitly setting IIR `filter_type`. This update switches `filter_type` to default to None, an if not explicitly set, it is inferred from the given parameters, with additional updates to check that the given set of parameters are consistent. 