### PR TITLE
[MNT] - Update procedures for "wrapper" funcs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -82,6 +82,7 @@ Hilbert Methods
 .. autosummary::
     :toctree: generated/
 
+    compute_instantaneous_measure
     robust_hilbert
     phase_by_time
     amp_by_time

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -21,7 +21,7 @@ from neurodsp.spectral.checks import check_spg_settings
 ###################################################################################################
 ###################################################################################################
 
-def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
+def compute_spectrum(sig, fs, method='welch', **kwargs):
     """Compute the power spectral density of a time series.
 
     Parameters
@@ -32,10 +32,9 @@ def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
         Sampling rate, in Hz.
     method : {'welch', 'wavelet', 'medfilt'}, optional
         Method to use to estimate the power spectrum.
-    avg_type : {'mean', 'median'}, optional
-        If relevant, the method to average across windows to create the spectrum.
     **kwargs
         Keyword arguments to pass through to the function that calculates the spectrum.
+        See `compute_spectrum_{welch, wavelet, medfilt}` for details.
 
     Returns
     -------
@@ -55,15 +54,31 @@ def compute_spectrum(sig, fs, method='welch', avg_type='mean', **kwargs):
     """
 
     check_param_options(method, 'method', ['welch', 'wavelet', 'medfilt'])
+    _spectrum_input_checks(method, kwargs)
 
     if method == 'welch':
-        return compute_spectrum_welch(sig, fs, avg_type=avg_type, **kwargs)
+        return compute_spectrum_welch(sig, fs, **kwargs)
 
     elif method == 'wavelet':
-        return compute_spectrum_wavelet(sig, fs, avg_type=avg_type, **kwargs)
+        return compute_spectrum_wavelet(sig, fs, **kwargs)
 
     elif method == 'medfilt':
         return compute_spectrum_medfilt(sig, fs, **kwargs)
+
+
+SPECTRUM_INPUTS = {
+    'welch' : ['avg_type', 'window', 'nperseg', 'noverlap', 'f_range', 'outlier_percent'],
+    'wavelet' : ['freqs', 'avg_type', 'n_cycles', 'scaling', 'norm'],
+    'medfilt' : ['filt_len', 'f_range'],
+}
+
+
+def _spectrum_input_checks(method, kwargs):
+    """Check inputs to `compute_spectrum` match spectral estimation method."""
+
+    for param in kwargs.keys():
+        assert param in SPECTRUM_INPUTS[method], \
+            'Parameter {} not expected for {} estimation method'.format(param, method)
 
 
 @multidim(select=[0])

--- a/neurodsp/tests/spectral/test_power.py
+++ b/neurodsp/tests/spectral/test_power.py
@@ -1,10 +1,13 @@
 """Tests for neurodsp.spectral.power."""
 
+from pytest import raises
+
 import numpy as np
 
 from neurodsp.tests.settings import FS, FREQ_SINE, FREQS_LST, FREQS_ARR, EPS
 
 from neurodsp.spectral.power import *
+from neurodsp.spectral.power import _spectrum_input_checks
 
 ###################################################################################################
 ###################################################################################################
@@ -19,6 +22,24 @@ def test_compute_spectrum(tsig):
 
     freqs, spectrum = compute_spectrum(tsig, FS, method='medfilt')
     assert freqs.shape == spectrum.shape
+
+
+SPECTRUM_INPUTS = {
+    'welch' : ['avg_type', 'window', 'nperseg', 'noverlap', 'f_range', 'outlier_percent'],
+    'wavelet' : ['freqs', 'avg_type', 'n_cycles', 'scaling', 'norm'],
+    'medfilt' : ['filt_len', 'f_range'],
+}
+
+def test_spectrum_input_checks():
+
+    # Test consistent examples
+    _spectrum_input_checks('welch', {'nperseg' : 500, 'noverlap' : 250})
+    _spectrum_input_checks('medfilt', {'filt_len' : 500})
+
+    # Test inconsistent examples
+    with raises(AssertionError):
+        _spectrum_input_checks('welch', {'filt_len' : 500})
+        _spectrum_input_checks('welch', {'nonsense' : 500})
 
 def test_compute_spectrum_2d(tsig2d):
 

--- a/neurodsp/tests/timefrequency/test_hilbert.py
+++ b/neurodsp/tests/timefrequency/test_hilbert.py
@@ -11,6 +11,12 @@ from neurodsp.utils.data import create_times
 ###################################################################################################
 ###################################################################################################
 
+def test_compute_instantaneous_measure(tsig_sine):
+
+    for measure in ['phase', 'amp', 'freq']:
+        out = compute_instantaneous_measure(tsig_sine, FS, measure)
+        assert out.shape == tsig_sine.shape
+
 def test_robust_hilbert(tsig_sine):
 
     # Generate a signal with NaNs

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -36,6 +36,22 @@ def compute_instantaneous_measure(sig, fs, measure, f_range=None,
     -------
     measure : 1d array
         Computed instantaneous measure.
+
+    Examples
+    --------
+    Simulate an example signal, with an alpha oscillation:
+
+    >>> from neurodsp.sim import sim_combined
+    >>> sig = sim_combined(n_seconds=10, fs=500,
+    ...                    components={'sim_powerlaw': {}, 'sim_oscillation': {'freq': 10}})
+
+    Compute the instantaneous phase of the signal:
+
+    >>> i_phase = compute_instantaneous_measure(sig, fs=500, measure='phase', f_range=(8, 12))
+
+    Compute the instantaneous amplitude of the signal:
+
+    >>> i_amp = compute_instantaneous_measure(sig, fs=500, measure='amp', f_range=(8, 12))
     """
 
     check_param_options(measure, 'measure', ['phase', 'amp', 'freq'])

--- a/neurodsp/timefrequency/hilbert.py
+++ b/neurodsp/timefrequency/hilbert.py
@@ -5,11 +5,50 @@ from scipy.signal import hilbert
 
 from neurodsp.filt import filter_signal
 from neurodsp.utils.decorators import multidim
+from neurodsp.utils.checks import check_param_options
 from neurodsp.utils.outliers import remove_nans, restore_nans
 from neurodsp.filt.utils import infer_passtype, remove_filter_edges
 
 ###################################################################################################
 ###################################################################################################
+
+def compute_instantaneous_measure(sig, fs, measure, f_range=None,
+                                  remove_edges=True, **filter_kwargs):
+    """Compute an instantaneous measure.
+
+    Parameters
+    ----------
+    sig : 1d array
+        Time series.
+    fs : float
+        Sampling rate, in Hz.
+    measure : {'phase', 'amp', 'freq'}
+        Which instantaneous measure to compute.
+    f_range : tuple of float or None, optional default: None
+        Filter range, in Hz, as (low, high). If None, no filtering is applied.
+    remove_edges : bool, optional, default: True
+        If True, replace samples that are within half of the filter's length to the edge with nan.
+        This removes edge artifacts from the filtered signal. Only used if `f_range` is defined.
+    **filter_kwargs
+        Keyword parameters to pass to `filter_signal`.
+
+    Returns
+    -------
+    measure : 1d array
+        Computed instantaneous measure.
+    """
+
+    check_param_options(measure, 'measure', ['phase', 'amp', 'freq'])
+
+    if measure == 'phase':
+        return phase_by_time(sig, fs, f_range, remove_edges, **filter_kwargs)
+
+    elif measure == 'amp':
+        return amp_by_time(sig, fs, f_range, remove_edges, **filter_kwargs)
+
+    elif measure == 'freq':
+        return freq_by_time(sig, fs, f_range, remove_edges, **filter_kwargs)
+
 
 @multidim()
 def robust_hilbert(sig):


### PR DESCRIPTION
Following from #322, in which `compute_spectrum` was used as a model for updating the 'wrapper' filter function, this PR takes the general approach that was expanded there and applies it back across other examples of using 'wrapper' functions in the module

Updates:
- Update `compute_spectrum` to have a more consistent API and use kwargs input checking
- Add a new 'wrapper' function for instantaneous measures
