### PR TITLE
[MNT] - Fix use of nans in test for new numpy

### DIFF
--- a/neurodsp/filt/utils.py
+++ b/neurodsp/filt/utils.py
@@ -162,7 +162,7 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
     >>> from neurodsp.filt.fir import design_fir_filter
     >>> filter_coefs = design_fir_filter(fs=500, pass_type='bandpass', f_range=(1, 25))
     >>> f_db, db = compute_frequency_response(filter_coefs, 1, fs=500)
-    >>> round(compute_transition_band(f_db, db, low=-20, high=-3), 1)
+    >>> round(float(compute_transition_band(f_db, db, low=-20, high=-3)), 1)
     0.5
 
     Compute the transition band of an IIR filter, using the computed frequency response:
@@ -171,7 +171,7 @@ def compute_transition_band(f_db, db, low=-20, high=-3):
     >>> sos = design_iir_filter(fs=500, pass_type='bandstop',
     ...                         f_range=(10, 20), butterworth_order=7)
     >>> f_db, db = compute_frequency_response(sos, None, fs=500)
-    >>> round(compute_transition_band(f_db, db, low=-20, high=-3), 1)
+    >>> round(float(compute_transition_band(f_db, db, low=-20, high=-3)), 1)
     2.0
     """
 

--- a/neurodsp/tests/utils/test_outliers.py
+++ b/neurodsp/tests/utils/test_outliers.py
@@ -11,13 +11,13 @@ from neurodsp.utils.outliers import *
 def test_remove_nans():
 
     # Test with an equal number of NaNs on either edge
-    arr = np.array([np.NaN, np.NaN, 1, 2, 3, np.NaN, np.NaN])
+    arr = np.array([np.nan, np.nan, 1, 2, 3, np.nan, np.nan])
     arr_no_nans, arr_nans = remove_nans(arr)
     assert_equal(arr_no_nans, np.array([1, 2, 3]))
     assert_equal(arr_nans, np.array([True, True, False, False, False, True, True]))
 
     # Test with a different number of NaNs on either edge
-    arr = np.array([np.NaN, np.NaN, 1, 2, 3, 4, np.NaN,])
+    arr = np.array([np.nan, np.nan, 1, 2, 3, 4, np.nan,])
     arr_no_nans, arr_nans = remove_nans(arr)
     assert_equal(arr_no_nans, np.array([1, 2, 3, 4]))
     assert_equal(arr_nans, np.array([True, True, False, False, False, False, True]))
@@ -28,7 +28,7 @@ def test_restore_nans():
     arr_nans = np.array([True, True, False, False, False, True])
 
     arr_restored = restore_nans(arr_no_nans, arr_nans)
-    assert_equal(arr_restored, np.array([np.NaN, np.NaN, 1, 2, 3, np.NaN]))
+    assert_equal(arr_restored, np.array([np.nan, np.nan, 1, 2, 3, np.nan]))
 
 def test_discard_outliers():
 


### PR DESCRIPTION
The tests are currently failing as new numpy has deprecated np.NaN, which we use in a couple of our tests. This PR fixes that. Other than our use of these NaN values in our tests, I don't think this switch from numpy should affect anything else. 

In addition there is a minor update to a doctest example, to fix an error with doctest being very pedantic with type (float vs numpy float). 