### PR TITLE
[MNT] - Fix power spectrum plot ylabel formatting

### DIFF
--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -61,7 +61,7 @@ def plot_power_spectra(freqs, powers, labels=None, colors=None, ax=None, **kwarg
         ax.loglog(freq, power, color=color, label=label)
 
     ax.set_xlabel('Frequency (Hz)')
-    ax.set_ylabel('Power (V^2/Hz)')
+    ax.set_ylabel('Power ($V^2/Hz$)')
 
 
 @savefig


### PR DESCRIPTION
Currently, the default y-label for a PSD plot is the string literal 'Power (V^2/Hz)', which isn't properly formatted to display the superscript exponent. 

This PR updates the formatting, to actually use a superscript, so the plot label now looks like this:
<img width="589" alt="Screen Shot 2024-11-16 at 4 37 52 PM" src="https://github.com/user-attachments/assets/000f5033-9628-4eaf-89a2-40ced9413795">

I think the only thing to consider / check is whether there is some reason this formatting might not work across systems(?). It works smoothly for me - would be good if someone else could check it renders properly. 
