### PR TITLE
[BUG] - Fix sim_bursty_oscillation for passing in burst_def array directly

### DIFF
--- a/neurodsp/plts/rhythm.py
+++ b/neurodsp/plts/rhythm.py
@@ -27,11 +27,11 @@ def plot_swm_pattern(pattern, ax=None, **kwargs):
     >>> import numpy as np
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.rhythm import sliding_window_matching
-    >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_powerlaw': {'f_range': (2, None)},
-    ...                                'sim_bursty_oscillation': {'freq': 20,
-    ...                                                           'enter_burst': .25,
-    ...                                                           'leave_burst': .25}})
+    >>> sim_components = {'sim_powerlaw': {'f_range': (2, None)},
+    ...                   'sim_bursty_oscillation': {'freq': 20,
+    ...                                              'burst_params': {'enter_burst' : 0.25,
+    ...                                                               'leave_burst' : 0.25}}}
+    >>> sig = sim_combined(n_seconds=10, fs=500, components=sim_components)
     >>> windows, _ = sliding_window_matching(sig, fs=500, win_len=0.05, win_spacing=0.5)
     >>> avg_window = np.mean(windows)
     >>> plot_swm_pattern(avg_window)
@@ -68,11 +68,11 @@ def plot_lagged_coherence(freqs, lcs, ax=None, **kwargs):
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.rhythm import compute_lagged_coherence
-    >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation': {'freq': 20,
-    ...                                                           'enter_burst': .50,
-    ...                                                           'leave_burst': .25}})
+    >>> sim_components = {'sim_synaptic_current': {},
+    ...                   'sim_bursty_oscillation': {'freq': 20,
+    ...                                              'burst_params': {'enter_burst' : 0.50,
+    ...                                                               'leave_burst' : 0.25}}}
+    >>> sig = sim_combined(n_seconds=10, fs=500, components=sim_components)
     >>> lag_cohs, freqs = compute_lagged_coherence(sig, fs=500, freqs=(5, 35),
     ...                                            return_spectrum=True)
     >>> plot_lagged_coherence(freqs, lag_cohs)

--- a/neurodsp/plts/spectral.py
+++ b/neurodsp/plts/spectral.py
@@ -151,9 +151,10 @@ def plot_scv_rs_matrix(freqs, t_inds, scv_rs, ax=None, **kwargs):
 
     >>> from neurodsp.sim import sim_combined
     >>> from neurodsp.spectral import compute_scv_rs
-    >>> sig = sim_combined(n_seconds=100, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation': {'freq': 10, 'enter_burst':0.75}})
+    >>> sim_components = {'sim_synaptic_current': {},
+    ...                   'sim_bursty_oscillation': {'freq': 10,
+    ...                                              'burst_params': {'enter_burst' : 0.75}}}
+    >>> sig = sim_combined(n_seconds=100, fs=500, components=sim_components)
     >>> freqs, t_inds, scv_rs = compute_scv_rs(sig, fs=500, method='rolling', rs_params=(10, 2))
     >>> # Plot the computed scv, plotting frequencies up to 20 Hz (index of 21)
     >>> plot_scv_rs_matrix(freqs[:21], t_inds, scv_rs[:21])

--- a/neurodsp/rhythm/lc.py
+++ b/neurodsp/rhythm/lc.py
@@ -59,11 +59,11 @@ def compute_lagged_coherence(sig, fs, freqs, n_cycles=3, return_spectrum=False):
     Compute lagged coherence for a simulated signal with beta oscillations:
 
     >>> from neurodsp.sim import sim_combined
-    >>> sig = sim_combined(n_seconds=10, fs=500,
-    ...                    components={'sim_synaptic_current': {},
-    ...                                'sim_bursty_oscillation': {'freq': 20,
-    ...                                                           'enter_burst': .50,
-    ...                                                           'leave_burst': .25}})
+    >>> sim_components = {'sim_synaptic_current': {},
+    ...                   'sim_bursty_oscillation': {'freq': 20,
+    ...                                              'burst_params': {'enter_burst' : 0.50,
+    ...                                                               'leave_burst' : 0.25}}}
+    >>> sig = sim_combined(n_seconds=10, fs=500, components=sim_components)
     >>> lag_cohs = compute_lagged_coherence(sig, fs=500, freqs=(5, 35))
     """
 

--- a/neurodsp/sim/periodic.py
+++ b/neurodsp/sim/periodic.py
@@ -154,7 +154,7 @@ def sim_bursty_oscillation(n_seconds, fs, freq, burst_def='prob', burst_params=N
     burst_params = {} if not burst_params else burst_params
     for burst_param in ['enter_burst', 'leave_burst']:
         temp = cycle_params.pop(burst_param, 0.2)
-        if burst_def == 'prob' and burst_param not in burst_params:
+        if isinstance(burst_def, str) and burst_def == 'prob' and burst_param not in burst_params:
             burst_params[burst_param] = temp
 
     # Simulate a normalized cycle to use for bursts

--- a/neurodsp/tests/sim/test_periodic.py
+++ b/neurodsp/tests/sim/test_periodic.py
@@ -67,6 +67,10 @@ def test_sim_bursty_oscillation():
         burst_def='durations', burst_params={'n_cycles_burst' : 2, 'n_cycles_off' : 2})
     check_sim_output(sig3)
 
+    # Check passing in burst definition directly
+    burst_def = np.array([True, False, True, False, True, False, True, False, True, False])
+    sig4 = sim_bursty_oscillation(1, FS, FREQ1, burst_def=burst_def)
+    check_sim_output(sig4, n_seconds=1)
 
 def test_sim_variable_oscillation():
 


### PR DESCRIPTION
Follow up from #334, implementing new fix discussed there

In the original PR @ryanhammonds pointed out there is a bug with `sim_bursty_oscillation` no longer taking in a pre-defined burst array properly. There are some quirks to keeping the ordering (see #334), so this PR adds a new fix 

Updates:
- add an explicit test of burst_def as an array input
- update the type-checking of `burst_def` to not fail with an array input
- update examples to more properly use a consistent API for passing in burst params
