### PR TITLE
[WIP] - Add / use / update compute_spectrogram

### DIFF
--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -381,3 +381,44 @@ def compute_spectrum_multitaper(sig, fs, bandwidth=None, n_tapers=None,
         spectrum = spectrum[0]
 
     return freqs, spectrum
+
+
+def compute_spectrogram(sig, fs, window='hann', nperseg=None, noverlap=0, nfft=None):
+    """Compute a spectrogram.
+
+    Parameters
+    ----------
+    sig : array
+        Time series.
+    fs : float
+        Sampling rate, in Hz.
+    window : str or tuple or array_like, optional, default: 'hann'
+        Desired window to use. See scipy.signal.get_window for a list of available windows.
+        If array_like, the array will be used as the window and its length must be nperseg.
+    nperseg : int, optional
+        Length of each segment, in number of samples.
+        If None, and window is str or tuple, is set to 1 second of data.
+        If None, and window is array_like, is set to the length of the window.
+    noverlap : int, optional
+        Number of points to overlap between segments.
+        If None, noverlap = nperseg // 8.
+    nfft : int, optional
+        Number of samples per window. Requires nfft > nperseg.
+        Windows are zero-padded by the difference, nfft - nperseg.
+
+    Returns
+    -------
+    freqs : 1d array
+        Frequencies at which the spectrogram was calculated.
+    times : 1d array
+        Time values at which the spectrogram was calculated.
+    spg : 2d array
+        Power values of the spectrogram.
+    """
+
+    nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)
+
+    freqs, times, spg = spectrogram(sig, fs, window, nperseg, noverlap, nfft,
+                                    detrend='constant', mode='magnitude')
+
+    return freqs, times, spg

--- a/neurodsp/spectral/power.py
+++ b/neurodsp/spectral/power.py
@@ -418,7 +418,6 @@ def compute_spectrogram(sig, fs, window='hann', nperseg=None, noverlap=0, nfft=N
 
     nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)
 
-    freqs, times, spg = spectrogram(sig, fs, window, nperseg, noverlap, nfft,
-                                    detrend='constant', mode='magnitude')
+    freqs, times, spg = spectrogram(sig, fs, window, nperseg, noverlap, nfft)
 
     return freqs, times, spg

--- a/neurodsp/spectral/variance.py
+++ b/neurodsp/spectral/variance.py
@@ -1,11 +1,11 @@
 """Compute spectral variance."""
 
 import numpy as np
-from scipy.signal import spectrogram
 
 from neurodsp.utils import discard_outliers
 from neurodsp.utils.decorators import multidim
 from neurodsp.utils.checks import check_param_options
+from neurodsp.spectral.power import compute_spectrogram
 from neurodsp.spectral.utils import trim_spectrum
 from neurodsp.spectral.checks import check_windowing_settings
 
@@ -56,9 +56,7 @@ def compute_scv(sig, fs, window='hann', nperseg=None, noverlap=0, outlier_pct=No
     >>> freqs, scv = compute_scv(sig, fs=500)
     """
 
-    # Compute spectrogram of data
-    nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)
-    freqs, _, spg = spectrogram(sig, fs, window, nperseg, noverlap)
+    freqs, _, spg = compute_spectrogram(sig, fs, window, nperseg, noverlap)
 
     if outlier_pct is not None:
         spg = discard_outliers(spg, outlier_pct)
@@ -134,10 +132,8 @@ def compute_scv_rs(sig, fs, window='hann', nperseg=None, noverlap=0,
     """
 
     check_param_options(method, 'method', ['bootstrap', 'rolling'])
-    nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)
 
-    # Compute spectrogram of data
-    freqs, ts, spg = spectrogram(sig, fs, window, nperseg, noverlap)
+    freqs, ts, spg = compute_spectrogram(sig, fs, window, nperseg, noverlap)
 
     if method == 'bootstrap':
 
@@ -228,9 +224,7 @@ def compute_spectral_hist(sig, fs, window='hann', nperseg=None, noverlap=None,
     >>> freqs, power_bins, spectral_hist = compute_spectral_hist(sig, fs=500)
     """
 
-    # Compute spectrogram of data
-    nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)
-    freqs, _, spg = spectrogram(sig, fs, window, nperseg, noverlap, return_onesided=True)
+    freqs, _, spg = compute_spectrogram(sig, fs, window, nperseg, noverlap)
 
     # Get log10 power & limit to frequency range of interest before binning
     ps = np.transpose(np.log10(spg))

--- a/neurodsp/tests/plts/test_aperiodic.py
+++ b/neurodsp/tests/plts/test_aperiodic.py
@@ -10,7 +10,7 @@ from neurodsp.plts.aperiodic import *
 ###################################################################################################
 ###################################################################################################
 
-def tests_plot_autocorr(tsig, tsig_comb):
+def test_plot_autocorr(tsig, tsig_comb):
 
     times1, acs1 = compute_autocorr(tsig, max_lag=150)
     times2, acs2 = compute_autocorr(tsig_comb, max_lag=150)

--- a/neurodsp/tests/spectral/test_power.py
+++ b/neurodsp/tests/spectral/test_power.py
@@ -136,3 +136,9 @@ def test_compute_spectrum_multitaper(tsig_sine, tsig2d):
     idx_freq_sine = np.argmin(np.abs(freqs - FREQ_SINE))
     idx_peak = np.argmax(spectrum)
     assert idx_freq_sine == idx_peak
+
+def test_compute_spectrogram(tsig):
+
+    freqs, times, spg = compute_spectrogram(tsig, FS)
+    assert freqs.shape[0] == spg.shape[0]
+    assert times.shape[0] == spg.shape[1]


### PR DESCRIPTION
This PR relates to the note about the spectrogram implementation in #344 - and also relates in part to discussion & updates in #357 and #358. Notably, while the #357 update moved away from using spectrogram in our Welch's function, this doesn't fully address the note about the implementation change in #344, since we use the `scipy.signal.spectrogram` function elsewhere.

To start with, this PR:
- adds an explicit `compute_spectrogram` function to unify and make explicit our use of spectrograms (this initial version uses `scipy.signal.spectrogram`, so no change in behavior)
- updates to use `compute_spectrogram` in relevant places in `neurodsp.spectral.variance`. 

From here, the question is which implementation of spectrogram to support. We can add (instead or in addition), the new [scipy.signal.ShortTimeFFT.spectrogram](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.spectrogram.html#scipy.signal.ShortTimeFFT.spectrogram) implementation. 

From here, we could update to use scipy's new implementation of spectrogram, and it would look something like this:
```
from scipy.signal import ShortTimeFFT
from neurodsp.spectral.checks import check_windowing_settings

def compute_spectrogram_new(sig, fs, window='hann', nperseg=None, noverlap=0, nfft=None):
    
    nperseg, noverlap = check_windowing_settings(fs, window, nperseg, noverlap)    

    stfft = ShortTimeFFT.from_window(window, fs=fs, nperseg=nperseg, noverlap=noverlap, mfft=nfft,
                                     fft_mode='onesided', scale_to='psd', phase_shift=None)
    spg = stfft.spectrogram(sig, detr='constant')
    
    return stfft.f, stfft.t(len(sig)), spg
```

However, there are some differences in the windowing and defaults that seem a bit nitpicky to solve. We would need to decide if / to what extent to match behavior between new & old (alternately: to what extent to just take the new behavior).

Relevant notes on aligning the implementations:
- https://docs.scipy.org/doc/scipy/tutorial/signal.html#comparison-with-legacy-implementation
- https://stackoverflow.com/questions/78975803/how-to-achieve-consistent-scaling-of-spectrograms-with-new-and-old-scipy-apis